### PR TITLE
new feature: "raw-soma-call"

### DIFF
--- a/dcm/.gitignore
+++ b/dcm/.gitignore
@@ -2,3 +2,4 @@
 /dcm-distros/
 /dist/
 /lib/
+/target/

--- a/dcm/deploy.ant.xml
+++ b/dcm/deploy.ant.xml
@@ -74,8 +74,9 @@
   
   valcred-from-def - create a valcred object based on a dcm:definition
   valcred-from-dir - create a valcred object from a set of certificates in a directory
-  
-  
+
+  raw-soma-call - make a raw SOMA call based on raw request file input
+
   This script relies on the following ANT properties:
   
     host - the hostname or IP address of the DataPower device
@@ -1255,7 +1256,12 @@
     </valcredFromFiles>
     
   </target>
-  
+
+	<target name="raw-soma-call" depends="-init-dir, -check-std-args">
+		<fail message="The Ant property 'soma.request' is required but not defined. This is the raw SOMA request filename." unless="soma.request"/>
+		<fail message="The Ant property 'soma.response' is required but not defined. This is the raw SOMA response filename." unless="soma.response"/>
+		<rawSomaCall host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" request="${soma.request}" response="${soma.response}"/>
+	</target>
 
   <target name="-check-std-args">
     

--- a/dcm/src/com/ibm/dcm/Soma.java
+++ b/dcm/src/com/ibm/dcm/Soma.java
@@ -306,6 +306,8 @@ public class Soma {
       result = doValCredAddCertsFromDir(params);
     } else if (somaOp.equals("WSRRSynchronize")) {
       result = doWSRRSynchronize(params);
+    } else if (somaOp.equals("RawSomaCall")) {
+        result = doRawSomaCall(params);
     } else {
       throw new UnsupportedOperationException ("soma=" + somaOp + " is not a recognized SOMA operation.");
     }
@@ -313,6 +315,48 @@ public class Soma {
     return result;
   }
 
+  /**
+   * This method implements the SomaCall operation.
+   * 
+   * The params must contain:
+   * 
+   * request= ... the request file name ... 
+   * response= ... the request file name ... 
+   * 
+   * @param params
+   * @return NamedParams "rawresponse".
+   * @throws Exception
+   */
+	public NamedParams doRawSomaCall(NamedParams params) throws Exception {
+		params.insistOn(new String[] { "request", "response" });
+		String request = readFile(params.get("request"));
+		NamedParams result = params;
+		result = conn.sendAndReceive(params, request);
+		String raw = result.get("rawresponse");
+		String responseFileName = params.get("response");
+		PrintWriter out = new PrintWriter(responseFileName);
+		out.println(raw);
+		out.close();
+		return result;
+	}
+
+	private static String readFile(String file) throws IOException {
+		BufferedReader reader = new BufferedReader(new FileReader(file));
+		String line = null;
+		StringBuilder stringBuilder = new StringBuilder();
+		String ls = System.getProperty("line.separator");
+
+		try {
+			while ((line = reader.readLine()) != null) {
+				stringBuilder.append(line);
+				stringBuilder.append(ls);
+			}
+
+			return stringBuilder.toString();
+		} finally {
+			reader.close();
+		}
+	}
 
   /**
    * This method implements the AddKnownHost operation.

--- a/dcm/src/dcm-taskdefs.ant.xml
+++ b/dcm/src/dcm-taskdefs.ant.xml
@@ -3453,8 +3453,26 @@
       </if>
     </sequential>
   </macrodef>
-  
-  
+
+	<macrodef name="rawSomaCall">
+		<attribute name="host"/>
+		<attribute name="port" default="5550"/>
+		<attribute name="uid"/>
+		<attribute name="pwd"/>
+		<attribute name="request"/>
+		<attribute name="response"/>
+		<sequential>
+			<wdp operation="RawSomaCall" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
+				<hostname>@{host}</hostname>
+				<port>@{port}</port>
+				<uid>@{uid}</uid>
+				<pwd>@{pwd}</pwd>
+				<request>@{request}</request>
+				<response>@{response}</response>
+			</wdp>
+		</sequential>
+	</macrodef>
+
   <!-- Convenient definition for using Xalan, specifically, to process XSLT. -->
   <macrodef name="xalan">
     <attribute name="in"/>


### PR DESCRIPTION
Please accept my new feature contribution, namely the "raw-soma-call" target.

It is very simple, taking as input a SOMA request file as input and writing the response to an output file. This is a very useful tool to experiment with the SOMA interface prior to perhaps adding new DCM features, or simply manipulating request/response XML with XSLT for bespoke managment tasks that do not justify a new DCM feature.