### PR TITLE
Upgraded 'raw-soma-call' to 'raw-mgmt-call' allowing non-SOMA methods

### DIFF
--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -63,7 +63,7 @@
   
   objects-from-def - create, delete, or modify objects based on dcm:object-* elements
 
-  raw-soma-call - make a raw SOMA call based on raw request file input
+  raw-mgmt-call - make a raw management (SOMA or AMP etc) call based on raw request file input
 
   save - save the domain
 
@@ -141,8 +141,8 @@
   <property name="capturesoma" value=""/>
   <property name="dumpinput" value="false"/>
   <property name="dumpoutput" value="false"/>
-  
-  
+  <property name="mgmt.method" value="/service/mgmt/current"/>
+
   <!--
     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
       Provide necessary definitions
@@ -1289,10 +1289,10 @@
     
   </target>
 
-	<target name="raw-soma-call" depends="-init-dir, -check-std-args">
-		<fail message="The Ant property 'soma.request' is required but not defined. This is the raw SOMA request filename." unless="soma.request"/>
-		<fail message="The Ant property 'soma.response' is required but not defined. This is the raw SOMA response filename." unless="soma.response"/>
-		<rawSomaCall host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" request="${soma.request}" response="${soma.response}"/>
+	<target name="raw-mgmt-call" depends="-init-dir, -check-std-args">
+		<fail message="The Ant property 'mgmt.request' is required but not defined. This is the raw management request filename." unless="mgmt.request"/>
+		<fail message="The Ant property 'mgmt.response' is required but not defined. This is the raw management response filename." unless="mgmt.response"/>
+		<rawMgmtCall host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" request="${mgmt.request}" response="${mgmt.response}" method="${mgmt.method}"/>
 	</target>
 
   <target name="-check-std-args">

--- a/src/com/ibm/dcm/SSLConnection.java
+++ b/src/com/ibm/dcm/SSLConnection.java
@@ -73,14 +73,18 @@ public class SSLConnection {
     HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
   }
 
-
+  // default to SOMA method for backwards compatibility
   public NamedParams sendAndReceive (NamedParams params, String request) throws Exception {
+	  return sendAndReceive(params, request, "/service/mgmt/current");
+  }
+
+  public NamedParams sendAndReceive (NamedParams params, String request, String method) throws Exception {
     String hostname = params.get("hostname");
     if (params.get("host") != null) {
       // Code is inconsistent in using "host" or "hostname".  Oh well.
       hostname = params.get("host");
     }
-    String url = "https://" + hostname + ":" + params.get("port") + "/service/mgmt/current";
+    String url = "https://" + hostname + ":" + params.get("port") + method;
     boolean dumpinput = false;
     if (params.get("dumpinput") != null && params.get("dumpinput").equals("true"))
       dumpinput = true;

--- a/src/com/ibm/dcm/Soma.java
+++ b/src/com/ibm/dcm/Soma.java
@@ -218,8 +218,8 @@ public class Soma {
       result = doQuiesceFSH(params);
     } else if (somaOp.equals("QuiesceService")) {
       result = doQuiesceService(params);
-    } else if (somaOp.equals("RawSomaCall")) {
-        result = doRawSomaCall(params);
+    } else if (somaOp.equals("RawMgmtCall")) {
+        result = doRawMgmtCall(params);
     } else if (somaOp.equals("RefreshDocument")) {
       result = doRefreshDocument(params);
     } else if (somaOp.equals("RefreshStylesheet")) {
@@ -322,16 +322,20 @@ public class Soma {
    * 
    * request= ... the request file name ... 
    * response= ... the request file name ... 
-   * 
+   *
+   * The params may contain:
+   *
+   * method= ... the management method (default is '/service/mgmt/current' - i.e. SOMA) ...
+   *
    * @param params
    * @return NamedParams "rawresponse".
    * @throws Exception
    */
-	public NamedParams doRawSomaCall(NamedParams params) throws Exception {
+	public NamedParams doRawMgmtCall(NamedParams params) throws Exception {
 		params.insistOn(new String[] { "request", "response" });
 		String request = readFile(params.get("request"));
 		NamedParams result = params;
-		result = conn.sendAndReceive(params, request);
+		result = conn.sendAndReceive(params, request, params.get("method"));
 		String raw = result.get("rawresponse");
 		String responseFileName = params.get("response");
 		PrintWriter out = new PrintWriter(responseFileName);

--- a/src/dcm-taskdefs.ant.xml
+++ b/src/dcm-taskdefs.ant.xml
@@ -2353,23 +2353,25 @@
   </macrodef>
 
 	<!--
-		Make a raw SOMA call
+		Make a raw XML management call
 	-->
-	<macrodef name="rawSomaCall">
+	<macrodef name="rawMgmtCall">
 		<attribute name="host"/>
 		<attribute name="port" default="5550"/>
 		<attribute name="uid"/>
 		<attribute name="pwd"/>
 		<attribute name="request"/>
 		<attribute name="response"/>
+		<attribute name="method"/>
 		<sequential>
-			<wdp operation="RawSomaCall" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
+			<wdp operation="RawMgmtCall" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
 				<hostname>@{host}</hostname>
 				<port>@{port}</port>
 				<uid>@{uid}</uid>
 				<pwd>@{pwd}</pwd>
 				<request>@{request}</request>
 				<response>@{response}</response>
+				<method>@{method}</method>
 			</wdp>
 		</sequential>
 	</macrodef>


### PR DESCRIPTION
My first iteration of this feature only had access to the SOMA interface directly. It has been widened to allow access to the AMP and all other methods (the default it SOMA however). Unfortunately I had to rename the target and parameters for it to make sense. Seeing as the feature was only a week old I I doubt many scripts got broken however :-)