### PR TITLE
Download specified files from a domain's filestore

### DIFF
--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -589,8 +589,35 @@
     <unquiesceDomain host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
     
   </target>
-  
-  
+
+	
+  <!--
+      Download target files or all files from a filestore
+  -->
+  <target name="download-files" depends="-init-dir, check-access">
+    
+    <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
+    <fail message="The Ant property 'filestore' is required but not defined.  This is filestore in the device." unless="filestore"/>
+  	<fail message="The Ant property 'download-dir.to' is required but not defined. This local directory will contain the downloaded files." unless="download-dir.to"/>
+  	
+    <if>
+      <isset property="files"/>
+      <then>
+      	<!-- download target files -->
+        <downloadFiles host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" 
+          dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"  
+          filestore="${filestore}" local="${download-dir.to}" files="${files}" />
+      </then>
+      <else>
+        <!-- download all files from the target filestore -->
+        <downloadFilestore host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" 
+          dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"  
+          filestore="${filestore}" local="${download-dir.to}" dcmdir="${dcm.dir}" />
+      </else>
+    </if>
+  </target> 
+	
+	
   <!--
       Export an object from a domain on the device.
   -->

--- a/src/dcm-taskdefs.ant.xml
+++ b/src/dcm-taskdefs.ant.xml
@@ -704,6 +704,63 @@
 
   <!--
     
+    Download target files from filestore 
+    
+    Required parameters:
+      host - hostname or IP address of DataPower device
+      domain - name of domain
+      filestore - name of filestore (e.g. local:, store:)
+      files - target files to download from the filestore
+      local - target directory in local filesystem
+      uid - userid
+      pwd - password
+    
+    Optional parameters:
+      port - XML Management Interface port on device (defaults to 5550)
+    
+  -->
+  <macrodef name="downloadFiles">
+    <attribute name="host"/>
+    <attribute name="port" default="5550"/>
+    <attribute name="uid"/>
+    <attribute name="pwd"/>
+    <attribute name="domain"/>
+    <attribute name="filestore"/>
+    <attribute name="files"/>
+    <attribute name="local" default="."/>
+    <attribute name="dumpinput" default="false"/>
+    <attribute name="dumpoutput" default="false"/>
+    <attribute name="capturesoma" default=""/>
+
+    <sequential>
+      <echo>Download target files: @{files}</echo>
+      <echo>from @{filestore} to @{local}</echo>
+
+      <forxpath inprop="files" xpath="/downloadFiles/file" propname="filename">
+        <sequential>
+          <dirname property="dirpath" file="@{local}@{filename}"/>
+          <mkdir dir="${dirpath}"/>
+
+          <echo>Downloading @{filestore}@{filename} to @{local}@{filename}</echo>
+          <wdp operation="GetFile" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
+            <domain>@{domain}</domain>
+            <hostname>@{host}</hostname>
+            <port>@{port}</port>
+            <uid>@{uid}</uid>
+            <pwd>@{pwd}</pwd>
+            <local>@{local}@{filename}</local>
+            <remote>@{filestore}@{filename}</remote>
+          </wdp>
+        </sequential>
+      </forxpath>
+      
+    </sequential>
+    
+  </macrodef>
+
+	
+	<!--
+    
     Download a filestore
     
     Required parameters:
@@ -732,6 +789,8 @@
     <attribute name="capturesoma" default=""/>
     
     <sequential>
+      <echo>Download all files from @{filestore} to @{local}</echo>
+    	
       <local name="rawxml"/>
       <local name="tmp"/>
       

--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -124,7 +124,7 @@
   </meta-html>
     
   <!-- Do not change the release-version, the build process injects it. -->
-  <release-version>9</release-version>
+  <release-version>10</release-version>
     
     
   <release-notes>
@@ -139,6 +139,7 @@
     <release-note plugin-version="7"> Expose UploadFromDef, GetObjectStatus, RestartDomain. </release-note>
     <release-note plugin-version="8"> Move xalan to apache-ant/lib, use current version of ant (1.9.7). </release-note>
     <release-note plugin-version="9"> Export Object </release-note>
+    <release-note plugin-version="10"> Download Files </release-note>
     
   </release-notes>
 </pluginInfo>

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -19,7 +19,7 @@
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <header>
-    <identifier version="9" id="com.ibm.datapower" name="DataPower"/>
+    <identifier version="10" id="com.ibm.datapower" name="DataPower"/>
     <description>The IBM WebSphere DataPower plugin deploys DataPower services.</description>
     <tag>Infrastructure/WebSphere DataPower</tag>
   </header>
@@ -472,6 +472,61 @@
       <arg value="-Ddomain=@domainName@"/>
       <arg value="-Denvironment=@environment@"/>
       <arg value="domain-delete"/>
+    </command>
+  </step-type>
+
+
+
+  <step-type name="Download Files">
+    <description>Download target files or all files from a filestore</description>
+    <properties>
+      <property name="domainName" required="true">
+        <property-ui type="textBox" default-value="${p:dpDomainName}" label="Domain name" description="Name of the target domain"/>
+      </property>
+      <property name="filestore" required="true">
+        <property-ui type="textBox" default-value="local:" label="Filestore name" description="Name of filestore (e.g. local:, store:)"/>
+      </property>
+      <property name="files">
+        <property-ui type="textBox" default-value="" label="Target files (blank means all)" description="All files if empty or target files e.g. &lt;downloadFiles&gt;&lt;file&gt;/folderA/fileA.xml&lt;/file&gt;&lt;/downloadFiles&gt;"/>
+      </property>
+      <property name="toDir" required="true">
+        <property-ui type="textBox" default-value="" label="To directory" description="This local directory will contain the downloaded files"/>
+      </property>
+      <property name="hostname">
+        <property-ui type="textBox" default-value="${p:dpHostname}" label="DataPower hostname/IP" description="Hostname or IP address of DataPower appliance" hidden="true"/>
+      </property>
+      <property name="uid">
+        <property-ui type="textBox" default-value="${p:dpUserid}" label="DataPower userid" description="Userid on DataPower appliance" hidden="true"/>
+      </property>
+      <property name="pwd">
+        <property-ui type="secureBox" default-value="${p:dpPassword}" label="DataPower password" description="Password for userid on DataPower appliance" hidden="true"/>
+      </property>
+      <property name="portXMI">
+        <property-ui type="textBox" default-value="${p:dpXMIPort}" label="DataPower XMI port" description="XML Management Interface port on DataPower appliance (usually 5550)" hidden="true"/>
+      </property>
+      <property name="addlProperties">
+        <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+    </properties>
+    <post-processing><![CDATA[
+    if (properties.get("exitCode") != 0) {
+            properties.put(new java.lang.String("Status"), new java.lang.String("Failure"));
+        }
+        else {
+            properties.put("Status", "Success");
+        }
+     ]]></post-processing>
+    <command program="${GROOVY_HOME}/bin/groovy">
+      <arg value="-cp"/>
+      <arg file="classes"/>
+      <arg file="RunDeployDotAnt.groovy"/>
+      <arg file="${PLUGIN_INPUT_PROPS}"/>
+      <arg file="${PLUGIN_OUTPUT_PROPS}"/>
+      <arg value="-Ddomain=@domainName@"/>
+      <arg value="-Dfilestore=@filestore@"/>
+      <arg value="-Dfiles=@files@"/>
+      <arg value="-Ddownload-dir.to=@toDir@"/>
+      <arg value="download-files"/>
     </command>
   </step-type>
 

--- a/src/main/zip/upgrade.xml
+++ b/src/main/zip/upgrade.xml
@@ -193,61 +193,7 @@
     <migrate-command  name="Upload Directory"/>
     <migrate-command  name="Upload From Definition"/>
   </migrate>
-  
-  <migrate to-version="9">
-    <migrate-command  name="Backup Device"/>
-    <migrate-command  name="Backup Domains"/>
-    <migrate-command  name="Checkpoint Delete"/>
-    <migrate-command  name="Checkpoint Restore"/>
-    <migrate-command  name="Checkpoint Save"/>
-    <migrate-command  name="Create Domain"/>
-    <migrate-command  name="Crypto Identity Credential from Definition"/>
-    <migrate-command  name="Crypto Validation Credential from Definition"/>
-    <migrate-command  name="Delete Domain"/>
-    <migrate-command  name="Host Alias Remove"/>
-    <migrate-command  name="Host Alias Set"/>
-    <migrate-command  name="Import (Basic)"/>
-    <migrate-command  name="Import (Definition)"/>
-    <migrate-command  name="Import (Deployment Policy Object)"/>
-    <migrate-command  name="Invoke any deploy.ant.xml target"/>
-    <migrate-command  name="Load Balancer Group from Definition"/>
-    <migrate-command  name="Quiesce Domain"/>
-    <migrate-command  name="Restart Domain"/>
-    <migrate-command  name="Restore Backup"/>
-    <migrate-command  name="Save Configuration"/>
-    <migrate-command  name="Set Log Level"/>
-    <migrate-command  name="Unquiesce Domain"/>
-    <migrate-command  name="Upload Directory"/>
-    <migrate-command  name="Upload From Definition"/>
-  </migrate>
-  
-  <migrate to-version="10">
-    <migrate-command  name="Backup Device"/>
-    <migrate-command  name="Backup Domains"/>
-    <migrate-command  name="Checkpoint Delete"/>
-    <migrate-command  name="Checkpoint Restore"/>
-    <migrate-command  name="Checkpoint Save"/>
-    <migrate-command  name="Create Domain"/>
-    <migrate-command  name="Crypto Identity Credential from Definition"/>
-    <migrate-command  name="Crypto Validation Credential from Definition"/>
-    <migrate-command  name="Delete Domain"/>
-    <migrate-command  name="Host Alias Remove"/>
-    <migrate-command  name="Host Alias Set"/>
-    <migrate-command  name="Import (Basic)"/>
-    <migrate-command  name="Import (Definition)"/>
-    <migrate-command  name="Import (Deployment Policy Object)"/>
-    <migrate-command  name="Invoke any deploy.ant.xml target"/>
-    <migrate-command  name="Load Balancer Group from Definition"/>
-    <migrate-command  name="Quiesce Domain"/>
-    <migrate-command  name="Restart Domain"/>
-    <migrate-command  name="Restore Backup"/>
-    <migrate-command  name="Save Configuration"/>
-    <migrate-command  name="Set Log Level"/>
-    <migrate-command  name="Unquiesce Domain"/>
-    <migrate-command  name="Upload Directory"/>
-    <migrate-command  name="Upload From Definition"/>
-  </migrate>
-
+ 
   <migrate to-version="9">
     <migrate-command  name="Backup Device"/>
     <migrate-command  name="Backup Domains"/>
@@ -276,4 +222,33 @@
     <migrate-command  name="Upload From Definition"/>
   </migrate>
 
+  <migrate to-version="10">
+    <migrate-command  name="Backup Device"/>
+    <migrate-command  name="Backup Domains"/>
+    <migrate-command  name="Checkpoint Delete"/>
+    <migrate-command  name="Checkpoint Restore"/>
+    <migrate-command  name="Checkpoint Save"/>
+    <migrate-command  name="Create Domain"/>
+    <migrate-command  name="Crypto Identity Credential from Definition"/>
+    <migrate-command  name="Crypto Validation Credential from Definition"/>
+    <migrate-command  name="Delete Domain"/>
+    <migrate-command  name="Download Files"/>
+    <migrate-command  name="Export Object"/>
+    <migrate-command  name="Host Alias Remove"/>
+    <migrate-command  name="Host Alias Set"/>
+    <migrate-command  name="Import (Basic)"/>
+    <migrate-command  name="Import (Definition)"/>
+    <migrate-command  name="Import (Deployment Policy Object)"/>
+    <migrate-command  name="Invoke any deploy.ant.xml target"/>
+    <migrate-command  name="Load Balancer Group from Definition"/>
+    <migrate-command  name="Quiesce Domain"/>
+    <migrate-command  name="Restart Domain"/>
+    <migrate-command  name="Restore Backup"/>
+    <migrate-command  name="Save Configuration"/>
+    <migrate-command  name="Set Log Level"/>
+    <migrate-command  name="Unquiesce Domain"/>
+    <migrate-command  name="Upload Directory"/>
+    <migrate-command  name="Upload From Definition"/>
+  </migrate>
+  
 </plugin-upgrade>


### PR DESCRIPTION
Hello Administrators,

This is wrt. issue https://github.com/ibm-datapower/datapower-configuration-manager/issues/30

This commit introduces a new plugin step called "Download Files" with the following ability:
- download target files from a filestore (implemented by a new downloadFiles taskdef)
- download all files from a filestore (implemented by existing downloadFilestore taskdef)

I have also modified the usual suspects (but ideally, the person doing the next release should review these in case there are more plugins):
- plugin.xml
- upgrade.xml
- info.xml

cheers
Wen
