### PR TITLE
Added 'export-objects' feature

### DIFF
--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -41,6 +41,7 @@
   domain-unquiesce - unquiesce all the services in the domain
   
   export-object - export an object i.e. service
+  export-objects - export objects based on a dcm:definition file
   
   host-alias-remove - remove a specific host alias
   host-alias-set - create/overwrite a host alias
@@ -656,7 +657,48 @@
       objclass="${object.class}" objname="${object.name}" refobjs="${ref.objects}" reffiles="${ref.files}" />
     
   </target>
-  
+
+	  <!--
+	      Export objects based on a dcm:definition file.
+	  -->
+	  <target name="export-objects" depends="-init-dir, check-access">
+	    
+	    <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
+	    <fail message="The Ant property 'export-manifest.file' is required but not defined.  This is the required export-manifest dcm:definition file." unless="export-manifest.file"/>
+	    <fail message="The Ant property 'export.file' is required but not defined.  This is the filename where the backup will be written." unless="export.file"/>
+	    
+	    <property name="ref.objects" value="true"/> <!-- provide defaults if not specified by user -->
+	    <property name="ref.files" value="true"/>
+	    
+	    <sequential>
+	      <local name="dirname"/>
+	      <dirname property="dirname" file="${export.file}"/>
+	      <if>
+	        <not>
+	          <isfileselected file="${dirname}">
+	            <writable/>
+	          </isfileselected>
+	        </not>
+	        <then>
+	          <fail message="No permission to write ${export.file} into folder ${dirname}"/>
+	        </then>
+	      </if>
+	    	
+			<!-- Generate a SOMA export objects request xml-->
+			<nxslt infile="${export-manifest.file}" outprop="tmp" xsl="${dcm.dir}/src/export-objects-request.xsl">
+				<param xsl="domain" ant="${domain}"/>
+			</nxslt>
+
+	    	<!-- Log results to console -->
+			<echo message="${tmp}" />
+
+	    	<exportObjects host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" local="${export.file}" 
+		      dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}" 
+		      objects="${tmp}" refobjs="${ref.objects}" reffiles="${ref.files}" />
+
+	    </sequential>
+	    	    
+	  </target>
 	
 	<!--
     Rollback to the previous firmware (and filesystem contents!).

--- a/src/dcm-taskdefs.ant.xml
+++ b/src/dcm-taskdefs.ant.xml
@@ -140,6 +140,71 @@
     </sequential>
   </macrodef>
 
+	  <!--
+	    Export the specified objects (name and class) in a ZIP format.
+	    
+	    Required parameters:
+	      host - hostname or IP address of DataPower device
+	      uid - userid
+	      pwd - password
+	      local - filename for ZIP file created by this operation
+	      objects - target objects to be exported
+
+	    Optional parameters:
+	      port - XML Management Interface port on device (defaults to 5550)
+	      ignore-errors - defaults to false
+	      refobjs - Include referenced objects? defaults to true
+	      reffiles - Include referenced files? defaults to true 
+	    
+	  -->
+		<macrodef name="exportObjects">
+	    <attribute name="domain"/>
+	    <attribute name="host"/>
+	    <attribute name="local"/>
+	    <attribute name="port" default="5550"/>
+	    <attribute name="uid"/>
+	    <attribute name="pwd"/>
+	    <attribute name="dumpinput" default="false"/>
+	    <attribute name="dumpoutput" default="false"/>
+	    <attribute name="capturesoma" default=""/>
+	    <attribute name="ignore-errors" default="false"/>
+	  	
+	    <attribute name="objects"/>
+	    <attribute name="refobjs"  default="true"/>
+	    <attribute name="reffiles" default="true"/>
+	  	
+	    <sequential>
+	      <local name="export_success"/>
+	      <local name="export_response"/>
+	    	
+	      <!-- Export the specified object based on the options given. -->
+	      <wdp operation="Export" successprop="export_success" responseprop="export_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
+	          <objects>@{objects}</objects>
+	          <local>@{local}</local>
+	          <hostname>@{host}</hostname>
+	          <port>@{port}</port>
+	          <uid>@{uid}</uid>
+	          <pwd>@{pwd}</pwd>
+	          <ignore-errors>@{ignore-errors}</ignore-errors>
+	          <domain>@{domain}</domain>
+	      </wdp>
+	      
+	      <if>
+	        <equals arg1="${export_success}" arg2="true"/>
+	        <then>
+	          <echo>Exported object @{objname} into @{local} where</echo>
+	          <echo>class=@{objclass} ref-objects=@{refobjs} ref-files=@{reffiles} domain=@{domain} hostname=@{host}.</echo>
+	        </then>
+	        <else>
+	          <echo>Raw response for export: ${export_response}</echo>
+	          <fail message="Failed to export object @{objname} of class=@{objclass} from domain @{domain} on @{host}."/>
+	        </else>
+	      </if>
+	        	
+	    </sequential>
+	  </macrodef>
+
+	
   <!--
     
     Backup some set of domains in a ZIP format.  Backups up the domain=Xxxx domain plus

--- a/src/export-objects-request.xsl
+++ b/src/export-objects-request.xsl
@@ -1,0 +1,17 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	version="1.0" xmlns:dp="http://www.datapower.com/schemas/management"
+	xmlns:dcm="urn:datapower:configuration:manager">
+
+	<xsl:param name="domain" />
+
+	<xsl:template match="export-object">
+		<dp:object name="{@name}" class="{@class}" ref-objects="{@ref-objects}"
+			ref-files="{@ref-files}" />
+	</xsl:template>
+
+	<xsl:template match="/">
+		<xsl:apply-templates
+			select="/dcm:definition/dcm:export-manifest/export-object" />
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/tests-deploy.ant/all-tests.ant.xml
+++ b/tests-deploy.ant/all-tests.ant.xml
@@ -16,7 +16,7 @@
   <fail message="Please don't define the 'domain' property since it interferes with some of the tests." if="domain"/>
 
 
-	<target name="all-tests" depends="backup-device,backup-domains,checkpoints,host-alias,import,lbg,restore,upload,object-status">
+	<target name="all-tests" depends="backup-device,backup-domains,checkpoints,host-alias,import,lbg,restore,upload,object-status,export-objects">
 		<!--
   			NOTE: some test cases are NOT included in all-tests for various reasons, namely:
 
@@ -29,8 +29,8 @@
 	</target>
 
 	<target name="-init">
-		<delete dir="tmp"/>
-		<mkdir dir="tmp"/>
+		<delete dir="${tmp.dir}"/>
+		<mkdir dir="${tmp.dir}"/>
 	</target>
 
   <target name="setup" depends="-init" unless="test.skip-setup">
@@ -214,6 +214,15 @@
 		<ant antfile="../deploy.ant.xml" target="object-status">
 			<property name="domain" value="dcm-test"/>
 			<property name="object-status.file" location="object-status.dcm.xml"/>
+		</ant>
+	</target>
+
+	<target name="export-objects" depends="setup" description="Export Objects">
+		<!-- TODO: add negative test cases; this is only positive -->
+		<ant antfile="../deploy.ant.xml" target="export-objects">
+			<property name="domain" value="dcm-test"/>
+			<property name="export-manifest.file" location="export-objects.dcm.xml"/>
+			<property name="export.file" location="${tmp.dir}/export-objects.zip"/>
 		</ant>
 	</target>
 

--- a/tests-deploy.ant/export-objects.dcm.xml
+++ b/tests-deploy.ant/export-objects.dcm.xml
@@ -1,0 +1,10 @@
+<dcm:definition xmlns:dcm="urn:datapower:configuration:manager">
+	<!-- export object(s) -->
+	<dcm:export-manifest>
+		<!-- TODO: add test objects that reference other objects and files -->
+		<export-object name="default" class="HTTPUserAgent"
+			ref-objects="true" ref-files="true" />
+		<export-object name="default-accept-service-providers"
+			class="StylePolicy" ref-objects="true" ref-files="true" />
+	</dcm:export-manifest>
+</dcm:definition>


### PR DESCRIPTION
This new feature exports multiple objects based on a dcm: definition file.

I apologise in advance (again!) for not having documented this new feature yet. I have however again added a test case to all-test.xml (target name="export-objects") - it's pretty self explanatory.

I'll get onto documenting the 3 or so features I've added over the next few weeks..

Cheers,
Sam