### PR TITLE
Increase Java Max Memory Size

### DIFF
--- a/src/main/zip/RunDeployDotAnt.groovy
+++ b/src/main/zip/RunDeployDotAnt.groovy
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 IBM Corp.
+ * Copyright 2015, 2017 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
- 
+
 import com.urbancode.air.AirPluginTool
 import com.urbancode.air.CommandHelper
 
-try 
+try
 {
   def apTool = new AirPluginTool(args[0], args[1])
   def props = apTool.getStepProperties()
@@ -56,16 +56,29 @@ try
   def dcmDir = ch.getProcessBuilder().environment().get('PLUGIN_HOME') + '/dcm'
   def anthome = dcmDir + '/apache-ant-1.9.7/'
   ch.addEnvironmentVariable('ANT_HOME', anthome)
-  
+
+  // Get ANT_OPTS environment variable
+  def envVars = System.getenv()
+  def antOpts = envVars['ANT_OPTS']?:""
+
+  // Add -Xmx###m if specified
+  def memorySize = props['memorySize']
+  if (memorySize != "default") {
+      antOpts = antOpts.trim() ? antOpts.trim() + " " : ""
+      antOpts += memorySize
+      println "[Ok] Setting Java Max Memory Size as '${memorySize}'."
+  }
+  ch.addEnvironmentVariable('ANT_OPTS', antOpts)
+
   // Construct the initial set of arguments for the ant command.
   def isWindows = (System.getProperty('os.name') =~ /(?i)windows/).find()
   def antexe = isWindows ? "ant.bat" : "ant"
-  def antargs = [anthome + "bin/" + antexe, 
-                 '-f', dcmDir + '/deploy.ant.xml', 
-                 '-Ddcm.dir=' + dcmDir, 
-                 '-Dhost=' + props['hostname'], 
-                 '-Dport=' + props['portXMI'], 
-                 '-Duid=' + props['uid'], 
+  def antargs = [anthome + "bin/" + antexe,
+                 '-f', dcmDir + '/deploy.ant.xml',
+                 '-Ddcm.dir=' + dcmDir,
+                 '-Dhost=' + props['hostname'],
+                 '-Dport=' + props['portXMI'],
+                 '-Duid=' + props['uid'],
                  '-Dpwd=' + props['pwd'],
                  '-Dwork.dir=' + ch.getProcessBuilder().directory().getAbsolutePath() + '/tmp']
 
@@ -99,7 +112,7 @@ try
       println '### arg[' + i + ']=' + arg
     }
     // Check the argument for occurrences of every property.
-    props.each{ 
+    props.each{
       it.toString().find('([^=]+)=(.*)') { match, propname, propvalue ->
         // The property=value has been split into propname and propvalue.
         if (debug) {
@@ -124,10 +137,9 @@ try
       }
     }
   }
+
   ch.runCommand(antargs.join(' '), antargs)
 } catch (e) {
   println e
   System.exit 1
 }
-
-

--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 /**
- * Copyright 2014 IBM Corp.
+ * Copyright 2014, 2017 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,128 +18,133 @@
  -->
  <pluginInfo>
   <!--
-  
+
   **author name IS required**
-  
+
   The Author Section is used to give credit to the author of the plugin.
-  Name is the only required element/attribute, but feel free to also include your email, 
-  website  or bio to allow users of your plugin to praise your work, ask questions 
-  or share their use case to help grow your plugin's functionality. 
+  Name is the only required element/attribute, but feel free to also include your email,
+  website  or bio to allow users of your plugin to praise your work, ask questions
+  or share their use case to help grow your plugin's functionality.
   -->
-  
+
   <author name="IBM">
     <organization>IBM</organization>
     <email>ucplugin@us.ibm.com</email>
     <website>https://www.ibmdw.net/urbancode/plugins/</website>
     <bio/>
   </author>
-   
+
   <!--
-  
+
   **intergration type IS Required**
-  
+
   The integration type section identifies where the plugin fits into the process
-  excepted types are SCM, Build, Artifact, Automation, Deploy 
-  
+  excepted types are SCM, Build, Artifact, Automation, Deploy
+
   For example:
-  
+
   The plugin pulls Artifacts from an artifact repository during deployment
   the Type would be "Artifact"
-  or 
-  The plugin deploys to a middleware server 
+  or
+  The plugin deploys to a middleware server
   the Type would be "Deploy"
   -->
-  
+
   <integration type="deploy"/>
-  
-  
-  <!-- 
+
+
+  <!--
   **source is NOT required**
-  
+
   The source section identifies the location of the plugin source code
-  For example 
+  For example
   https://github.com/...
   -->
   <source url="https://github.com/ibm-datapower/datapower-configuration-manager"/>
-  <!-- 
+  <!--
   **license type is NOT required**
-  
-  If your plugin uses any licensed software please acknowledge it by 
-  listing the license type below  
-  
-  Apache Ant is a software tool to automate software processes during the build or 
-  deployment of an application. Ant uses an propitiatory XML file to define build 
-  and/or deployment steps(referred to as targets by ant) . The Ant executable is 
+
+  If your plugin uses any licensed software please acknowledge it by
+  listing the license type below
+
+  Apache Ant is a software tool to automate software processes during the build or
+  deployment of an application. Ant uses an propitiatory XML file to define build
+  and/or deployment steps(referred to as targets by ant) . The Ant executable is
   called to execute the targets in the build.xml.-->
-  
+
   <licenses>
     <license type="Apache2"/>
   </licenses>
-  
-  <!-- 
+
+  <!--
   **tool-description IS required**
-  
-  The tool-description section is used to summarize the software 
-  the plugin was created to integrate with. 
-  
-  For example: 
-  Apache Ant is a software tool to automate software processes during the build or 
-  deployment of an application. Ant uses an propitiatory XML file to define build 
-  and/or deployment steps(referred to as targets by ant) . The Ant executable is 
+
+  The tool-description section is used to summarize the software
+  the plugin was created to integrate with.
+
+  For example:
+  Apache Ant is a software tool to automate software processes during the build or
+  deployment of an application. Ant uses an propitiatory XML file to define build
+  and/or deployment steps(referred to as targets by ant) . The Ant executable is
   called to execute the targets in the build.xml.
   -->
-  
+
   <tool-description> IBM DataPower is a network security appliance.  This plugin assists in deploying services to DataPower appliances. </tool-description>
-  
-  <!-- 
+
+  <!--
   **related-info is NOT required**
-  
-  The releated-info section is used to define links which may be useful to users of the plugin 
-  but don't fall into the release-notes or tool-description section. 
-  
+
+  The releated-info section is used to define links which may be useful to users of the plugin
+  but don't fall into the release-notes or tool-description section.
+
   For example: releated-info can be links to pdf documentation, help videos related to plugin setup or the product's
   website.
-  
-  excepted values for type include: PDF, WEBSITE, VIDEO  
+
+  excepted values for type include: PDF, WEBSITE, VIDEO
   -->
-  
+
   <related-info>
     <link description="Please visit the DataPower version 7.0 (or later) support web site" title="IBM DataPower Homepage" type="WEBSITE" url="http://www-01.ibm.com/support/knowledgecenter/SS9H2Y_7.0.0/com.ibm.dp.doc/welcome.html"/>
   </related-info>
-  
-  <!-- 
+
+  <!--
   **meta-html in NOT required**
-  
-  The meta-html section is used define the meta description and the meta keywords of the plugin page.The meta 
-  description tag allows you to influence the description of your page in the web crawlers that support the 
-  tag The meta keywords tag allows   you to provide additional text for crawler-based search engines to index 
-  along with your body copy. 
-  
-  If multiple keywords are used they must be comma(,) delimited   
-  -->  
-  
+
+  The meta-html section is used define the meta description and the meta keywords of the plugin page.The meta
+  description tag allows you to influence the description of your page in the web crawlers that support the
+  tag The meta keywords tag allows   you to provide additional text for crawler-based search engines to index
+  along with your body copy.
+
+  If multiple keywords are used they must be comma(,) delimited
+  -->
+
   <meta-html>
     <meta content="" name="description"/>
-    <meta content="" name="keywords"/>  
+    <meta content="" name="keywords"/>
   </meta-html>
-    
+
   <!-- Do not change the release-version, the build process injects it. -->
-  <release-version>10</release-version>
-    
-    
+  <release-version>11</release-version>
+
+
   <release-notes>
     <!--
       **release-note IS required**
-      
-      The plugin-version name must match the plugin version found in the plugin.xml file 
+
+      The plugin-version name must match the plugin version found in the plugin.xml file
     -->
-	  
+
     <release-note plugin-version="1"> Initial release. </release-note>
     <release-note plugin-version="2"> Fix issue #1 - set ANT_HOME to plugin's version of Ant. </release-note>
     <release-note plugin-version="7"> Expose UploadFromDef, GetObjectStatus, RestartDomain. </release-note>
     <release-note plugin-version="8"> Move xalan to apache-ant/lib, use current version of ant (1.9.7). </release-note>
     <release-note plugin-version="9"> Export Object </release-note>
     <release-note plugin-version="10"> Download Files </release-note>
-    
+    <release-note plugin-version="11">
+        New functionality added to all steps:
+            - The ANT_OPTS varaible is applied to all commands.
+            - Specify the hidden Java Max Memory Size variable to increase the Ant commands JVM size.
+    </release-note>
+
   </release-notes>
 </pluginInfo>

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -51,7 +51,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -112,7 +112,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -172,7 +172,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -231,7 +231,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -290,7 +290,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -346,7 +346,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -404,7 +404,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -463,7 +463,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -519,7 +519,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -580,7 +580,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -649,7 +649,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -708,7 +708,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -774,7 +774,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -835,7 +835,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -897,7 +897,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -960,7 +960,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1023,7 +1023,7 @@
         <property-ui type="textBox" default-value="${p:dpXMIPort}" label="DataPower XMI port" description="XML Management Interface port on DataPower appliance (usually 5550)" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1081,7 +1081,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1137,7 +1137,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1192,7 +1192,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1252,7 +1252,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1309,7 +1309,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1375,7 +1375,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1431,7 +1431,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1492,7 +1492,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>
@@ -1552,7 +1552,7 @@
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
       <property name="memorySize">
-        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+        <property-ui type="selectBox" default-value="default" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
           <value label="Default">default</value>
           <value label="-Xmx256m">-Xmx256m</value>
           <value label="-Xmx512m">-Xmx512m</value>

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
- * Copyright 2014, 2015 IBM Corp.
+ * Copyright 2014, 2017 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <header>
-    <identifier version="10" id="com.ibm.datapower" name="DataPower"/>
+    <identifier version="11" id="com.ibm.datapower" name="DataPower"/>
     <description>The IBM WebSphere DataPower plugin deploys DataPower services.</description>
     <tag>Infrastructure/WebSphere DataPower</tag>
   </header>
@@ -49,6 +49,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -103,6 +111,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -155,6 +171,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -205,6 +229,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -257,6 +289,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -304,6 +344,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -354,6 +402,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -406,6 +462,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -453,6 +517,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -506,6 +578,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -568,6 +648,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -592,9 +680,9 @@
       <arg value="export-object"/>
     </command>
   </step-type>
-  
-  
-  
+
+
+
   <step-type name="Host Alias Remove">
     <description>Remove a host alias</description>
     <properties>
@@ -618,6 +706,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -677,6 +773,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -729,6 +833,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -783,6 +895,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -839,6 +959,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -894,6 +1022,14 @@
       <property name="portXMI">
         <property-ui type="textBox" default-value="${p:dpXMIPort}" label="DataPower XMI port" description="XML Management Interface port on DataPower appliance (usually 5550)" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -944,6 +1080,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -992,6 +1136,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -1038,6 +1190,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -1091,6 +1251,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -1139,6 +1307,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -1198,6 +1374,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -1245,6 +1429,14 @@
       </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -1299,6 +1491,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -1351,6 +1551,14 @@
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
+      <property name="memorySize">
+        <property-ui type="selectBox" default-value="" label="Java Max Memory Size" description="Set the max Java Heap Memory size for the DCM's Ant call. " hidden="true"/>
+          <value label="Default">default</value>
+          <value label="-Xmx256m">-Xmx256m</value>
+          <value label="-Xmx512m">-Xmx512m</value>
+          <value label="-Xmx1024m">-Xmx1024m</value>
+          <value label="-Xmx2048m">-Xmx2048m</value>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -1372,7 +1580,4 @@
       <arg value="upload-from-def"/>
     </command>
   </step-type>
-
-
-
 </plugin>

--- a/src/main/zip/upgrade.xml
+++ b/src/main/zip/upgrade.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
- * Copyright 2014, 2015 IBM Corp.
+ * Copyright 2014, 2017 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 <plugin-upgrade
         xmlns="http://www.urbancode.com/UpgradeXMLSchema_v1"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  
+
   <migrate to-version="2">
     <migrate-command  name="Backup Device"/>
     <migrate-command  name="Backup Domains"/>
@@ -41,7 +41,7 @@
     <migrate-command  name="Unquiesce Domain"/>
     <migrate-command  name="Upload Directory"/>
   </migrate>
-  
+
   <migrate to-version="3">
     <migrate-command  name="Backup Device"/>
     <migrate-command  name="Backup Domains"/>
@@ -63,7 +63,7 @@
     <migrate-command  name="Unquiesce Domain"/>
     <migrate-command  name="Upload Directory"/>
   </migrate>
-  
+
   <migrate to-version="4">
     <migrate-command  name="Backup Device"/>
     <migrate-command  name="Backup Domains"/>
@@ -87,7 +87,7 @@
     <migrate-command  name="Unquiesce Domain"/>
     <migrate-command  name="Upload Directory"/>
   </migrate>
-  
+
   <migrate to-version="5">
     <migrate-command  name="Backup Device"/>
     <migrate-command  name="Backup Domains"/>
@@ -112,7 +112,7 @@
     <migrate-command  name="Unquiesce Domain"/>
     <migrate-command  name="Upload Directory"/>
   </migrate>
-  
+
   <migrate to-version="6">
     <migrate-command  name="Backup Device"/>
     <migrate-command  name="Backup Domains"/>
@@ -139,7 +139,7 @@
     <migrate-command  name="Upload Directory"/>
     <migrate-command  name="Upload From Definition"/>
   </migrate>
-  
+
   <migrate to-version="7">
     <migrate-command  name="Backup Device"/>
     <migrate-command  name="Backup Domains"/>
@@ -166,7 +166,7 @@
     <migrate-command  name="Upload Directory"/>
     <migrate-command  name="Upload From Definition"/>
   </migrate>
-  
+
   <migrate to-version="8">
     <migrate-command  name="Backup Device"/>
     <migrate-command  name="Backup Domains"/>
@@ -193,7 +193,7 @@
     <migrate-command  name="Upload Directory"/>
     <migrate-command  name="Upload From Definition"/>
   </migrate>
- 
+
   <migrate to-version="9">
     <migrate-command  name="Backup Device"/>
     <migrate-command  name="Backup Domains"/>
@@ -250,5 +250,138 @@
     <migrate-command  name="Upload Directory"/>
     <migrate-command  name="Upload From Definition"/>
   </migrate>
-  
+
+  <migrate to-version="11">
+    <migrate-command  name="Backup Device">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Backup Domains">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Checkpoint Delete">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Checkpoint Restore">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Checkpoint Save">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Create Domain">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Crypto Identity Credential from Definition">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Crypto Validation Credential from Definition">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Delete Domain">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Download Files">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Export Object">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Host Alias Remove">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Host Alias Set">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Import (Basic)">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Import (Definition)">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Import (Deployment Policy Object)">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Invoke any deploy.ant.xml target">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Load Balancer Group from Definition">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Quiesce Domain">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Restart Domain">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Restore Backup">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Save Configuration">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Set Log Level">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Unquiesce Domain">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Upload Directory">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Upload From Definition">
+      <migrate-properties>
+        <migrate-property name="memorySize" default=""/>
+      </migrate-properties>
+    </migrate-command>
+  </migrate>
+
 </plugin-upgrade>

--- a/src/main/zip/upgrade.xml
+++ b/src/main/zip/upgrade.xml
@@ -254,132 +254,132 @@
   <migrate to-version="11">
     <migrate-command  name="Backup Device">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Backup Domains">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Checkpoint Delete">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Checkpoint Restore">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Checkpoint Save">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Create Domain">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Crypto Identity Credential from Definition">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Crypto Validation Credential from Definition">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Delete Domain">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Download Files">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Export Object">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Host Alias Remove">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Host Alias Set">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Import (Basic)">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Import (Definition)">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Import (Deployment Policy Object)">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Invoke any deploy.ant.xml target">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Load Balancer Group from Definition">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Quiesce Domain">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Restart Domain">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Restore Backup">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Save Configuration">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Set Log Level">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Unquiesce Domain">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Upload Directory">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
     <migrate-command  name="Upload From Definition">
       <migrate-properties>
-        <migrate-property name="memorySize" default=""/>
+        <migrate-property name="memorySize" default="default"/>
       </migrate-properties>
     </migrate-command>
   </migrate>


### PR DESCRIPTION
- Added new property to every step that can increase the max size of the
JVM at runtime of the Ant command. This will help eliminate Java Out of
Memory exceptions.
- Bumped to version 11