### PR TITLE
Datapower Version 13

### DIFF
--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -18,19 +18,19 @@
  -->
 <!--
   This stylesheet performs DataPower deployment operations:
-  
+
   certificate-from-def - upload a cert (or multiple certs) based on a dcm:definition (with Crypto Certificate objects, of course)
-  
+
   check-access - check whether the device is accessible and that the userid/password works
-  
+
   checkpoint-delete - delete the specified checkpoint
   checkpoint-restore - restore from the specified checkpoint
   checkpoint-save - create/overwrite the specified checkpoint
-  
+
   create-tam-files - Create TAM files based on a whole bunch of parameters
-  
+
   clean - delete any temp files created by this ant script
-  
+
   domain-create - ensure the domain exists
   domain-delete - delete the domain
   domain-init - delete and recreate the domain, then upload the standard files
@@ -39,29 +39,29 @@
   domain-reset - clear all the objects from the domain (but not files)
   domain-restart - restart the domain
   domain-unquiesce - unquiesce all the services in the domain
-  
+
   export-object - export an object i.e. service
   export-objects - export objects based on a dcm:definition file
-  
+
   host-alias-remove - remove a specific host alias
   host-alias-set - create/overwrite a host alias
-  
+
   idcred-from-def - create an idcred object based on a dcm:definition
   idcred-from-key-and-cert - create an idcred object after uploading matching key and certificate files
   idcred-from-p12 - create an idcred object after uploading a #PKCS12 file containing matching key and certificate
-  
+
   import-changed - import a specified .zip or .xcfg file into the domain, making changes along the way
   import-from-def - ditto
   import-dpo - import a specified .zip or .xcfg file into the domain, making changes along the way
-  
+
   key-from-def - upload a key (or multiple keys) based on a dcm:definition (with Crypto Key objects, of course)
-  
+
   load-balancer-group-from-def - create/overwrite a load balancer group object
-  
+
   ltpa-password - prompt the console user for the LTPA shared-secret password
-  
+
   main (default target) - execute the import-changed and save targets (in that order)
-  
+
   objects-from-def - create, delete, or modify objects based on dcm:object-* elements
 
   object-status - check the opstate of objects are as required based on a dcm:definition file
@@ -77,68 +77,68 @@
   service-quiesce - quiesce a service
   service-unquiesce -unquiesce a service
   service-status - get the opstate of a service
-  
+
   upload-dir - upload an entire directory
   upload-from-def - upload files specified in dcm:definition/dcm:upload elements
-  
+
   valcred-from-def - create a valcred object based on a dcm:definition
   valcred-from-dir - create a valcred object from a set of certificates in a directory
 
   This script relies on the following ANT properties:
-  
+
     host - the hostname or IP address of the DataPower device
     domain - the name of the domain on that device
     uid - the userid on that device
     pwd - the password for the userid on that device
     port - the XML Management Interface port on that device (optional, defaults to 5550)
-  
+
     dcm.jar - location of DCM jar file
     work.dir - location of DCM temp directory
     dcm.dir - location of DCM stylesheets directory
-    schema.dir - location of directory used by DCM to cache internally-generated schemas 
-    
+    schema.dir - location of directory used by DCM to cache internally-generated schemas
+
   IF YOU ARE NEW TO ANT:
-  
+
     Ant executes the specified "targets" in the order that you specified them on the command line, or
     it executes the "main" target, which is the default.  Each target may depend on other targets, and those
     will be executed first.  For example, the "main" target depends on "domain-create", which in turn depends on
     "check-access".  So Ant will begin by executing the "check-access" target, then the "domain-create"
     target, and finally the "main" target.  Oh, and the code preceding all the <target> elements is initialization
     code and will be executed before everything else.  Targets that are defined but not needed are ignored.
-    
+
     Properties are the lifeblood of Ant.  A property is simply a name/value pair and it can be set once.  Further
     changes to a property are ignored.  For example, if the property xyz is defined on the command line like this:
-      
+
       ant -Dxyz=10
-      
+
     then xyz will have that value for the life of the Ant execution, regardless of how many times you attempt to
     set xyz after that.  Several places in the script provide default values for some properties but it isn't
     possible (or generally desirable) to prevent the user from setting a property either on the command line,
     or through a property file named on the command line.
-    
+
     Properties, once defined, exist for the rest of Ant's execution.  With one exception of course. ;)
     The lifetime of Ant properties can be confined by writing code this way:
-    
+
       <sequential>
         <local name="def"/>
         <property name="def" value="123"/>
         ...
       </sequential>
-    
+
     The property "def" will be forgotten at the end of the <sequential> task.
-    
+
     There you go.  With these concepts in hand, Ant scripts are generally straightforward to read.
-    
+
 -->
 <project name="deploy" default="main" xmlns:props="antlib:ibm">
 
   <description>Implement various DataPower deployment operations.</description>
-    
+
   <!-- Ensure we know where DCM is located. -->
   <fail message="Please define the ANT property 'dcm.dir', which points to the directory where DCM is installed." unless="dcm.dir"/>
   <available filepath="${dcm.dir}" file="dist/dcm.jar" property="dcm.dir.good"/>
   <fail message="The Ant property 'dcm.dir' doesn't seem to point to DCM since ${dcm.dir}/dist/dcm.jar is not found." unless="dcm.dir.good"/>
-  
+
   <!-- Provide reasonable defaults for some optional properties. -->
   <property name="dcm.jar" location="${dcm.dir}/dist/dcm.jar"/>
   <property name="work.dir" location="./tmp"/>
@@ -148,6 +148,7 @@
   <property name="dumpoutput" value="false"/>
   <property name="mgmt.method" value="/service/mgmt/current"/>
   <property name="reboot.mode" value="reboot"/>
+  <property name="ignore.error" value=""/>
 
   <!--
     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -174,7 +175,7 @@
     key and certificate files.
   -->
   <target name="backup-device" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'device.backup.file' is required but not defined.  This is the filename where the device backup will be written." unless="device.backup.file"/>
     <sequential>
       <local name="dirname"/>
@@ -190,21 +191,21 @@
         </then>
       </if>
     </sequential>
-    
+
     <!--
       Backup all the domains on the device, which is not a secure backup that includes
       key and certificate files.
     -->
     <backupDevice host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" local="${device.backup.file}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <!--
     Backup specific domains on the device.
   -->
   <target name="backup-domains" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'backup.file' is required but not defined.  This is the filename where the backup will be written." unless="backup.file"/>
     <sequential>
@@ -221,17 +222,17 @@
         </then>
       </if>
     </sequential>
-    
+
     <!--
       Backup the specified domains on the device.
     -->
     <backupDomains host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" domains="${domains}" local="${backup.file}"  saveIfNeeded="true" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <target name="certificate-from-def" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'cert.file' is required but not defined.  This is the file containing the dcm:definition/dcm:certificate definition." unless="cert.file"/>
     <if>
@@ -242,10 +243,10 @@
         <fail message="Unable to see the file containing the certificate definition : ${cert.file}"/>
       </then>
     </if>
-    
+
     <sequential>
       <local name="tmpl-file"/>
-      
+
       <!-- Generate an ant script that will do the actual work. -->
       <nxslt infile="${cert.file}" outprop="tmp" xsl="${dcm.dir}/src/remove-unwanted-elements.xsl">
         <param ant="environment" xsl="param1"/>
@@ -255,17 +256,17 @@
       <nxslt inprop="tmp" outfile="${work.dir}/cert.ant.xml" xsl="${dcm.dir}/src/certificate-to-ant.xsl">
         <param ant="tmpl-file" xsl="template-file"/>
       </nxslt>
-      
+
       <!-- Run the little darling, inheriting all the currently-defined ant properties. -->
       <ant antfile="${work.dir}/cert.ant.xml" inheritall="yes"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="check-access" depends="-check-std-args">
-    
-    <!-- 
+
+    <!--
       Check whether we have access to the device by fetching the firmware version.  Throws an exception, terminating Ant,
       in case of an error.  Also, detects that firmware.version is already set and does nothing in that case.
       In case of an error it throws an exception or prints the SOAP response and terminates Ant.
@@ -283,47 +284,47 @@
       </then>
     </if>
   </target>
-  
-  
+
+
   <target name="checkpoint-delete" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'checkpoint.name' is required but not defined.  This defines name of the checkpoint that will be deleted." unless="checkpoint.name"/>
-    
+
     <removeCheckpoint host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" checkpoint-name="${checkpoint.name}"
       dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <target name="checkpoint-restore" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'checkpoint.name' is required but not defined.  This defines name of the checkpoint that will be restored." unless="checkpoint.name"/>
-    
+
     <rollbackCheckpoint host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" checkpoint-name="${checkpoint.name}"
       dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <target name="checkpoint-save" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'checkpoint.name' is required but not defined.  This defines name of the checkpoint that will be saved." unless="checkpoint.name"/>
 
     <saveCheckpoint host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" checkpoint-name="${checkpoint.name}"
         dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <!-- All ANT scripts support this by convention. -->
   <target name="clean">
     <delete dir="${work.dir}"/>
   </target>
-  
-  
+
+
   <target name="create-tam-files" depends="-init-dir, check-access">
 
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
@@ -337,7 +338,7 @@
     <fail message="The Ant property 'tam.ssltimeout' is required but not defined.  This the number of seconds before the connection to TAM times out." unless="tam.ssltimeout"/>
     <fail message="The Ant property 'tam.localmode' is required but not defined.  This defines whether to use a local authentication server (on/off)." unless="tam.localmode"/>
     <fail message="The Ant property 'tam.useadregistry' is required but not defined.  This defines whether to use Active Directory (on/off)." unless="tam.useadregistry"/>
-    
+
     <if>
       <and>
         <not>
@@ -351,7 +352,7 @@
         </input>
       </then>
     </if>
-    
+
     <if>
       <and>
         <not>
@@ -365,7 +366,7 @@
         </input>
       </then>
     </if>
-    
+
     <sequential>
       <local name="okay"/>
       <local name="response"/>
@@ -421,7 +422,7 @@
       <defprop-set name="addomainreplicas" from="tam.addomainreplicas" defvalue=""/>
       <defprop-set name="aduseemailuid" from="tam.aduseemailuid" defvalue="off"/>
       <defprop-set name="adgchost" from="tam.adgchost" defvalue=""/>
-      
+
       <wdp operation="CreateTAMFiles" successprop="success" responseprop="response"  dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"
         xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="okay">
         <hostname>${host}</hostname>
@@ -466,7 +467,7 @@
         <aduseemailuid>${aduseemailuid}</aduseemailuid>
         <adgchost>${adgchost}</adgchost>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${success}"/>
@@ -480,22 +481,22 @@
           <fail message="Failed to create TAM files (${tam.outputconfigfile}) in ${domain} on ${host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <!-- All ANT scripts support this by convention. -->
   <target name="debug">
     <echo/>
     <echoproperties/>
     <echo/>
   </target>
-  
-  
+
+
   <target name="domain-create" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
 
     <!--
@@ -508,12 +509,12 @@
       <getDomainStatus host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domainsprop="domainstatus" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
       <saveDomainIfChanged host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domainStatusProp="domainstatus" domain="default" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="domain-delete" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
 
     <!--
@@ -526,24 +527,24 @@
       <getDomainStatus host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domainsprop="domainstatus" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
       <saveDomainIfChanged host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domainStatusProp="domainstatus" domain="default" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="domain-init" depends="domain-delete, domain-create">
-    
+
     <echo>Completed initialization of the domain.</echo>
-    
+
   </target>
-  
-  
+
+
   <target name="domain-recreate" depends="domain-delete, domain-create, save"/>
-  
-  
+
+
   <target name="domain-reset" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
-    
+
     <!--
       Resets the domain conventionally, when the domain exists, printing what it did.
       In case of an error it throws an exception or prints the SOAP response and terminates Ant.
@@ -554,12 +555,12 @@
       <getDomainStatus host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domainsprop="domainstatus" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
       <saveDomainIfChanged host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domainStatusProp="domainstatus" domain="${domain}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="domain-quiesce" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
 
     <!--
@@ -567,12 +568,12 @@
       In case of an error it throws an exception or prints the SOAP response and terminates Ant.
     -->
     <quiesceDomain host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <target name="domain-restart" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
 
     <!--
@@ -580,12 +581,12 @@
       In case of an error it throws an exception or prints the SOAP response and terminates Ant.
     -->
     <restartDomain host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <target name="domain-unquiesce" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
 
     <!--
@@ -593,50 +594,50 @@
       In case of an error it throws an exception or prints the SOAP response and terminates Ant.
     -->
     <unquiesceDomain host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
 
-	
+
   <!--
       Download target files or all files from a filestore
   -->
   <target name="download-files" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'filestore' is required but not defined.  This is filestore in the device." unless="filestore"/>
   	<fail message="The Ant property 'download-dir.to' is required but not defined. This local directory will contain the downloaded files." unless="download-dir.to"/>
-  	
+
     <if>
       <isset property="files"/>
       <then>
       	<!-- download target files -->
-        <downloadFiles host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" 
-          dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"  
+        <downloadFiles host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}"
+          dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"
           filestore="${filestore}" local="${download-dir.to}" files="${files}" />
       </then>
       <else>
         <!-- download all files from the target filestore -->
-        <downloadFilestore host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" 
-          dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"  
+        <downloadFilestore host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}"
+          dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"
           filestore="${filestore}" local="${download-dir.to}" dcmdir="${dcm.dir}" />
       </else>
     </if>
-  </target> 
-	
-	
+  </target>
+
+
   <!--
       Export an object from a domain on the device.
   -->
   <target name="export-object" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'object.class' is required but not defined.  This is the object's class." unless="object.class"/>
     <fail message="The Ant property 'object.name' is required but not defined.  This is the name of the target object on the DataPower device." unless="object.name"/>
     <fail message="The Ant property 'export.file' is required but not defined.  This is the filename where the backup will be written." unless="export.file"/>
-    
+
     <property name="ref.objects" value="true"/> <!-- provide defaults if not specified by user -->
     <property name="ref.files" value="true"/>
-    
+
     <sequential>
       <local name="dirname"/>
       <dirname property="dirname" file="${export.file}"/>
@@ -651,25 +652,25 @@
         </then>
       </if>
     </sequential>
-    
-    <exportObject host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" local="${export.file}" 
-      dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}" 
+
+    <exportObject host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" local="${export.file}"
+      dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"
       objclass="${object.class}" objname="${object.name}" refobjs="${ref.objects}" reffiles="${ref.files}" />
-    
+
   </target>
 
 	  <!--
 	      Export objects based on a dcm:definition file.
 	  -->
 	  <target name="export-objects" depends="-init-dir, check-access">
-	    
+
 	    <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
 	    <fail message="The Ant property 'export-manifest.file' is required but not defined.  This is the required export-manifest dcm:definition file." unless="export-manifest.file"/>
 	    <fail message="The Ant property 'export.file' is required but not defined.  This is the filename where the backup will be written." unless="export.file"/>
-	    
+
 	    <property name="ref.objects" value="true"/> <!-- provide defaults if not specified by user -->
 	    <property name="ref.files" value="true"/>
-	    
+
 	    <sequential>
 	      <local name="dirname"/>
 	      <dirname property="dirname" file="${export.file}"/>
@@ -683,7 +684,7 @@
 	          <fail message="No permission to write ${export.file} into folder ${dirname}"/>
 	        </then>
 	      </if>
-	    	
+
 			<!-- Generate a SOMA export objects request xml-->
 			<nxslt infile="${export-manifest.file}" outprop="tmp" xsl="${dcm.dir}/src/export-objects-request.xsl">
 				<param xsl="domain" ant="${domain}"/>
@@ -692,29 +693,29 @@
 	    	<!-- Log results to console -->
 			<echo message="${tmp}" />
 
-	    	<exportObjects host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" local="${export.file}" 
-		      dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}" 
+	    	<exportObjects host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" local="${export.file}"
+		      dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"
 		      objects="${tmp}" refobjs="${ref.objects}" reffiles="${ref.files}" />
 
 	    </sequential>
-	    	    
+
 	  </target>
-	
+
 	<!--
     Rollback to the previous firmware (and filesystem contents!).
   -->
   <target name="firmware-rollback" depends="-init-dir, check-access">
-    
+
     <firmwareRollback host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <!--
     Update to a new level of firmware.
   -->
   <target name="firmware-update" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'new.firmware.file' is required but not defined.  This is the file containing the the new firmware for the appliance." unless="new.firmware.file"/>
     <if>
       <not>
@@ -724,16 +725,16 @@
         <fail message="Unable to see the firmware file : ${new.firmware.file}"/>
       </then>
     </if>
-    
+
     <firmwareUpdate host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" scryptfile="${new.firmware.file}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <target name="host-alias-remove" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'host-alias.name' is required but not defined.  This is the name of the host alias (e.g. www.ibm.com) to delete." unless="host-alias.name"/>
-    
+
     <sequential>
       <!-- Create or overwrite the specified host alias. -->
       <objectDelete host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="default"
@@ -741,17 +742,17 @@
         dcmdir="${dcm.dir}" workdir="${work.dir}"
         dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="host-alias-set" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'host-alias.name' is required but not defined.  This is the name of the host alias (e.g. www.ibm.com) to create or overwrite." unless="host-alias.name"/>
     <fail message="The Ant property 'host-alias.ip' is required but not defined.  This is the IP address to assign (e.g. 10.11.12.13)." unless="host-alias.ip"/>
     <property name="host-alias.comment" value=""/>
     <property name="host-alias.mAdminState" value="enabled"/>
-    
+
     <sequential>
       <!-- Create or overwrite the specified host alias. -->
       <objectCreateByInline host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="default" versionprop="firmware.version"
@@ -763,12 +764,12 @@
         </HostAlias>
       </objectCreateByInline>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="idcred-from-def" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'idcred.file' is required but not defined.  This is the file containing the dcm:definition/dcm:idcred definition." unless="idcred.file"/>
     <if>
@@ -779,11 +780,11 @@
         <fail message="Unable to see the file containing the idcred definition : ${idcred.file}"/>
       </then>
     </if>
-    
+
     <sequential>
       <local name="tmp"/>
       <local name="tmpl-file"/>
-      
+
       <!-- Generate an ant script that will do the actual work. -->
       <property name="tmpl-file" location="${dcm.dir}/src/_quickie.template.ant.xml"/>
       <nxslt infile="${idcred.file}" outprop="tmp" xsl="${dcm.dir}/src/remove-unwanted-elements.xsl">
@@ -793,16 +794,16 @@
       <nxslt inprop="tmp" outfile="${work.dir}/idcred.ant.xml" xsl="${dcm.dir}/src/idcred-to-ant.xsl">
         <param ant="tmpl-file" xsl="template-file"/>
       </nxslt>
-      
+
       <!-- Run the little darling, inheriting all the currently-defined ant properties. -->
       <ant antfile="${work.dir}/idcred.ant.xml" inheritall="yes"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="idcred-from-key-and-cert" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'idcred.key.file' is required but not defined.  This is the file containing the key for the ID credential." unless="idcred.key.file"/>
     <if>
@@ -813,7 +814,7 @@
         <fail message="Unable to see the key file : ${idcred.key.file}"/>
       </then>
     </if>
-    
+
     <fail message="The Ant property 'idcred.cert.file' is required but not defined.  This is the file containing the certificate for the ID credential." unless="idcred.cert.file"/>
     <if>
       <not>
@@ -823,7 +824,7 @@
         <fail message="Unable to see the certificate file : ${idcred.cert.file}"/>
       </then>
     </if>
-    
+
     <fail message="The Ant property 'idcred.objname' is required but not defined.  This is the name for the ID Credential object to create/overwrite on DataPower." unless="idcred.objname"/>
     <if>
       <equals arg1="${idcred.objname}" arg2=""/>
@@ -831,7 +832,7 @@
         <fail message="The Ant property 'idcred.objname', which is the name of the ID Credential object, is empty!"/>
       </then>
     </if>
-    
+
     <if>
       <not>
         <isset property="idcred.key.pwd"/>
@@ -842,7 +843,7 @@
         </input>
       </then>
     </if>
-    
+
     <if>
       <not>
         <isset property="idcred.cert.pwd"/>
@@ -853,11 +854,11 @@
         </input>
       </then>
     </if>
-    
-    
+
+
     <sequential>
       <local name="ignoreexpiration"/>
-      
+
       <if>
         <and>
           <isset property="${idcred.ignoreexpiration}"/>
@@ -870,18 +871,18 @@
           <property name="ignoreexpiration" value="off"/>
         </else>
       </if>
-      
+
       <idcredFromKeyAndCert host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}"
-        certfile="${idcred.cert.file}" certpwd="${idcred.cert.pwd}" keyfile="${idcred.key.file}" keypwd="${idcred.key.pwd}" 
+        certfile="${idcred.cert.file}" certpwd="${idcred.cert.pwd}" keyfile="${idcred.key.file}" keypwd="${idcred.key.pwd}"
         objname="${idcred.objname}" ignoreexpiration="${ignoreexpiration}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-      
+
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="idcred-from-p12" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'idcred.p12.file' is required but not defined.  This is the #PKCS12-format file containing the key and certificate for the ID credential." unless="idcred.p12.file"/>
     <if>
@@ -892,7 +893,7 @@
         <fail message="Unable to see the #PKCS12 file : ${idcred.p12.file}"/>
       </then>
     </if>
-    
+
     <fail message="The Ant property 'idcred.objname' is required but not defined.  This is the name for the ID Credential object to create/overwrite on DataPower." unless="idcred.objname"/>
     <if>
       <equals arg1="${idcred.objname}" arg2=""/>
@@ -900,7 +901,7 @@
         <fail message="The Ant property 'idcred.objname', which is the name of the ID Credential object, is empty!"/>
       </then>
     </if>
-    
+
     <if>
       <not>
         <isset property="idcred.p12.pwd"/>
@@ -911,10 +912,10 @@
         </input>
       </then>
     </if>
-    
+
     <sequential>
       <local name="ignoreexpiration"/>
-      
+
       <if>
         <and>
           <isset property="${idcred.ignoreexpiration}"/>
@@ -931,17 +932,17 @@
       <idcredFromPKCS12 host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}"
         p12file="${idcred.p12.file}" p12pwd="${idcred.p12.pwd}" objname="${idcred.objname}" ignoreexpiration="${ignoreexpiration}"
         dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-      
+
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="import-changed" depends="import-from-def"/>
-  
-  
+
+
   <target name="import-from-def" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'import.file' is required but not defined.  This is the .zip or .xcfg file to import into the domain." unless="import.file"/>
     <if>
@@ -952,12 +953,12 @@
         <fail message="Unable to see the import file : ${import.file}"/>
       </then>
     </if>
-    
+
     <sequential>
       <local name="dcmdefinition"/>
       <local name="tmp"/>
       <local name="tmp2"/>
-      
+
       <!-- Load and preprocess the set of deployment policies, or substitute an empty set. -->
       <property name="import.changes.file" location="${dcm.dir}/src/no-changes.dcm.xml"/> <!-- provide a default, if property not defined. -->
       <loadfile srcfile="${import.changes.file}" property="tmp">
@@ -970,24 +971,24 @@
         <param ant="device" xsl="param2"/>
       </nxslt>
       <nxslt inprop="tmp2" outprop="dcmdefinition" xsl="${dcm.dir}/src/expand-black-white-modify.xsl"/>
-      
+
       <!-- <echo>dcmdefinition = ${dcmdefinition}</echo> -->
-      
+
       <!--
         Import a plain .zip or .xcfg file into the domain, making no changes to the import objects or files.
         In case of an error it throws an exception or prints the SOAP response and terminates Ant.
       -->
       <importConfig host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}"
-        inputfile="${import.file}"
+        inputfile="${import.file}" ignoreError="${ignore.error}"
         dcmdir="${dcm.dir}" workdir="${work.dir}" changes="${dcmdefinition}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="import-dpo" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'import.file' is required but not defined.  This is the .zip or .xcfg file to import into the domain." unless="import.file"/>
     <fail message="The Ant property 'deployment.policy.object' is required but not defined.  This name of a deployment policy object to apply during the import." unless="deployment.policy.object"/>
@@ -999,24 +1000,24 @@
         <fail message="Unable to see the import file : ${import.file}"/>
       </then>
     </if>
-    
+
     <sequential>
-      
+
       <!--
         Import a plain .zip or .xcfg file into the domain, making no changes to the import objects or files.
         In case of an error it throws an exception or prints the SOAP response and terminates Ant.
       -->
       <importConfigDPO host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}"
-        inputfile="${import.file}" dpo="${deployment.policy.object}"
+        inputfile="${import.file}" dpo="${deployment.policy.object}" ignoreError="${ignore.error}"
         dcmdir="${dcm.dir}" workdir="${work.dir}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-      
+
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="key-from-def" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'key.file' is required but not defined.  This is the file containing the dcm:definition/dcm:key definition." unless="key.file"/>
     <if>
@@ -1027,10 +1028,10 @@
         <fail message="Unable to see the file containing the key definition : ${key.file}"/>
       </then>
     </if>
-    
+
     <sequential>
       <local name="tmpl-file"/>
-      
+
       <!-- Generate an ant script that will do the actual work. -->
       <nxslt infile="${key.file}" outprop="tmp" xsl="${dcm.dir}/src/remove-unwanted-elements.xsl">
         <param ant="environment" xsl="param1"/>
@@ -1040,16 +1041,16 @@
       <nxslt inprop="tmp" outfile="${work.dir}/key.ant.xml" xsl="${dcm.dir}/src/key-to-ant.xsl">
         <param ant="tmpl-file" xsl="template-file"/>
       </nxslt>
-      
+
       <!-- Run the little darling, inheriting all the currently-defined ant properties. -->
       <ant antfile="${work.dir}/key.ant.xml" inheritall="yes"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="load-balancer-group-from-def" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'lbg.file' is required but not defined.  This is the file containing the dcm:definition/dcm:loadbalancergroup definition." unless="lbg.file"/>
     <if>
@@ -1060,11 +1061,11 @@
         <fail message="Unable to see the file containing the load balancer group definition : ${lbg.file}"/>
       </then>
     </if>
-    
+
     <sequential>
       <local name="tmp"/>
       <local name="tmpl-file"/>
-      
+
       <!-- Generate an ant script that will do the actual work. -->
       <property name="tmpl-file" location="${dcm.dir}/src/_quickie.template.ant.xml"/>
       <nxslt infile="${lbg.file}" outprop="tmp" xsl="${dcm.dir}/src/remove-unwanted-elements.xsl">
@@ -1075,16 +1076,16 @@
         <param ant="tmpl-file" xsl="template-file"/>
         <param ant="firmware.version" xsl="firmware-version"/>
       </nxslt>
-      
+
       <!-- Run the little darling, inheriting all the currently-defined ant properties. -->
       <ant antfile="${work.dir}/lbg.ant.xml" inheritall="yes"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="ltpa-password">
-    
+
     <!-- When ${ltpa.key.password} hasn't been set, ask the user for it. -->
     <if>
       <not>
@@ -1096,19 +1097,19 @@
         </input>
       </then>
     </if>
-    
+
   </target>
-  
-  
+
+
   <target name="main" depends="import-changed, save">
-    
+
     <echo>Completed import.</echo>
-    
+
   </target>
-  
-  
+
+
   <target name="objects-from-def" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'objects.file' is required but not defined.  This is the file containing the dcm:definition/dcm:object-* definition(s)." unless="objects.file"/>
     <if>
@@ -1119,11 +1120,11 @@
         <fail message="Unable to see the file containing the object definitions : ${objects.file}"/>
       </then>
     </if>
-    
+
     <sequential>
       <local name="tmp"/>
       <local name="tmpl-file"/>
-      
+
       <!-- Generate an ant script that will do the actual work. -->
       <property name="tmpl-file" location="${dcm.dir}/src/_quickie.template.ant.xml"/>
       <nxslt infile="${objects.file}" outprop="tmp" xsl="${dcm.dir}/src/remove-unwanted-elements.xsl">
@@ -1133,13 +1134,13 @@
       <nxslt inprop="tmp" outfile="${work.dir}/objects.ant.xml" xsl="${dcm.dir}/src/objects-to-ant.xsl">
         <param ant="tmpl-file" xsl="template-file"/>
       </nxslt>
-      
+
       <!-- Run the little darling, inheriting all the currently-defined ant properties. -->
       <ant antfile="${work.dir}/objects.ant.xml" inheritall="yes"/>
     </sequential>
-    
+
   </target>
-  
+
 	<!--
 		Check the opstate of objects are as required based on a dcm:definition file.
 	-->
@@ -1189,7 +1190,7 @@
 		</sequential>
 
 	</target>
-  
+
 	<!--
 		Reboot appliance request.
 	-->
@@ -1198,8 +1199,8 @@
 		<!-- Validate input parameters -->
 		<fail message="The Ant property 'reboot.mode' is required but not defined. Valid options are 'reboot' or 'reload'. The default is 'reboot'." unless="reboot.mode"/>
 
-		<!-- NB: always prefer to use the OLDEST AMP version (1.0) to provide greatest 
-			backwards compatibility with older firmware versions unless there is a good 
+		<!-- NB: always prefer to use the OLDEST AMP version (1.0) to provide greatest
+			backwards compatibility with older firmware versions unless there is a good
 			reason not to -->
 
 		<!-- Generate an AMP reset request xml file -->
@@ -1231,12 +1232,12 @@
 		</if>
 
 	</target>
-	
+
   <!--
     Restore domains from a device or multiple-domains backup.
   -->
   <target name="restore-backup" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'backup.file' is required but not defined.  This is the backup file containing multiple domains (see backup-device or backup-domains)." unless="backup.file"/>
     <property name="dry-run" value="false"/>
@@ -1248,16 +1249,16 @@
         <fail message="Unable to see the backup file : ${backup.file}"/>
       </then>
     </if>
-    
-    <restoreBackup host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" 
+
+    <restoreBackup host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}"
       domains="${domains}" zipfile="${backup.file}" dry-run="${dry-run}"
       dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <target name="save" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
 
     <!--
@@ -1269,7 +1270,7 @@
       <getDomainStatus host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domainsprop="domainstatus" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
       <saveDomainIfChanged host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domainStatusProp="domainstatus" domain="${domain}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
     </sequential>
-    
+
   </target>
 
 
@@ -1287,7 +1288,7 @@
 
   <!--
     Quiesce service.
-  -->	
+  -->
   <target name="service-quiesce" depends="-init-dir, check-access">
     <fail message="The Ant property 'domain' is required but not defined. This is the name of a domain on the DataPower device." unless="domain" />
     <fail message="The Ant property 'service.name' is required but not defined. This is the name of a service to be quiesced on the DataPower device." unless="service.name" />
@@ -1297,15 +1298,15 @@
       In case of an error it throws an exception or prints the SOAP response and terminates Ant.
     -->
     <quiesceService host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" servicename="${service.name}" servicetype="${service.type}" ignore-errors="${ignoreerrors}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}" />
-  
+
   </target>
 
 
   <!--
     Unquiesce service.
-  -->	
+  -->
   <target name="service-unquiesce" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined. This is the name of a domain on the DataPower device." unless="domain" />
     <fail message="The Ant property 'service.name' is required but not defined. This is the name of a service to be quiesced on the DataPower device." unless="service.name" />
     <fail message="The Ant property 'service.type' is required but not defined. This is the type of a service to be quiesced on the DataPower device." unless="service.type" />
@@ -1314,13 +1315,13 @@
       In case of an error it throws an exception or prints the SOAP response and terminates Ant.
     -->
     <unquiesceService host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" servicename="${service.name}" servicetype="${service.type}" ignore-errors="${ignoreerrors}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}" />
-    
+
   </target>
 
 
   <!--
     Get service status.
-  -->	
+  -->
   <target name="service-status">
 
     <fail message="The Ant property 'domain' is required but not defined. This is the name of a domain on the DataPower device." unless="domain" />
@@ -1331,38 +1332,38 @@
       In case of an error it throws an exception or prints the SOAP response and terminates Ant.
     -->
     <getServiceStatus host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" servicename="${service.name}" servicetype="${service.type}" outputprop="opstateprop" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}" />
-    
+
   </target>
 
-  
+
   <!--
     Set the default log level in a domain
   -->
   <target name="set-log-level" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'log.level' is required but not defined.  This is the log level to set (debug, info, noice, warn, error, critic, alert, emerg)." unless="log.level"/>
-    
+
     <setLogLevel host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" loglevel="${log.level}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <target name="upload-dir" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'upload-dir.from' is required but not defined.  This is the directory in the local filesystem to upload from (e.g. c:\abc or /home/xxx/abc)." unless="upload-dir.from"/>
     <fail message="The Ant property 'upload-dir.to' is required but not defined.  This is the fully qualified directory on DataPower to upload to (e.g. cert:/// or local:///abc)." unless="upload-dir.to"/>
-    
-    <dpupload dir="${upload-dir.from}" target="${upload-dir.to}" domain="${domain}" 
+
+    <dpupload dir="${upload-dir.from}" target="${upload-dir.to}" domain="${domain}"
       host="${host}" port="${port}" uid="${uid}" pwd="${pwd}"
       dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
-    
+
   </target>
-  
-  
+
+
   <target name="upload-from-def" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'upload.file' is required but not defined.  This is the file containing the dcm:definition/dcm:upload definition(s)." unless="upload.file"/>
     <if>
@@ -1373,11 +1374,11 @@
         <fail message="Unable to see the file containing the upload definition : ${upload.file}"/>
       </then>
     </if>
-    
+
     <sequential>
       <local name="tmp"/>
       <local name="tmpl-file"/>
-      
+
       <!-- Generate an ant script that will do the actual work. -->
       <property name="tmpl-file" location="${dcm.dir}/src/_quickie.template.ant.xml"/>
       <nxslt infile="${upload.file}" outprop="tmp" xsl="${dcm.dir}/src/remove-unwanted-elements.xsl">
@@ -1387,16 +1388,16 @@
       <nxslt inprop="tmp" outfile="${work.dir}/upload.ant.xml" xsl="${dcm.dir}/src/upload-to-ant.xsl">
         <param ant="tmpl-file" xsl="template-file"/>
       </nxslt>
-      
+
       <!-- Run the little darling, inheriting all the currently-defined ant properties. -->
       <ant antfile="${work.dir}/upload.ant.xml" inheritall="yes"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="valcred-from-def" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'valcred.file' is required but not defined.  This is the file containing the dcm:definition/dcm:valcred definition." unless="valcred.file"/>
     <if>
@@ -1407,11 +1408,11 @@
         <fail message="Unable to see the file containing the valcred definition : ${valcred.file}"/>
       </then>
     </if>
-    
+
     <sequential>
       <local name="tmp"/>
       <local name="tmpl-file"/>
-      
+
       <!-- Generate an ant script that will do the actual work. -->
       <property name="tmpl-file" location="${dcm.dir}/src/_quickie.template.ant.xml"/>
       <nxslt infile="${valcred.file}" outprop="tmp" xsl="${dcm.dir}/src/remove-unwanted-elements.xsl">
@@ -1421,16 +1422,16 @@
       <nxslt inprop="tmp" outfile="${work.dir}/valcred.ant.xml" xsl="${dcm.dir}/src/valcred-to-ant.xsl">
         <param ant="tmpl-file" xsl="template-file"/>
       </nxslt>
-      
+
       <!-- Run the little darling, inheriting all the currently-defined ant properties. -->
       <ant antfile="${work.dir}/valcred.ant.xml" inheritall="yes"/>
     </sequential>
-    
+
   </target>
-  
-  
+
+
   <target name="valcred-from-dir" depends="-init-dir, check-access">
-    
+
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
     <fail message="The Ant property 'valcred.dir' is required but not defined.  This is the path to the directory containing (only!) the certificate files to include in this valcred." unless="valcred.dir"/>
     <if>
@@ -1441,7 +1442,7 @@
         <fail message="Unable to see the directory containing certificate files : ${valcred.dir}"/>
       </then>
     </if>
-    
+
     <fail message="The Ant property 'valcred.objname' is required but not defined.  This is the name for the Validation Credential object to create/overwrite on DataPower." unless="valcred.objname"/>
     <if>
       <equals arg1="${valcred.objname}" arg2=""/>
@@ -1449,12 +1450,12 @@
         <fail message="The Ant property 'valcred.objname', which is the name of the Validation Credential object, is empty!"/>
       </then>
     </if>
-    
+
     <valcredFromFiles host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}"
       dcmdir="${dcm.dir}" rootdir="${valcred.dir}" objname="${valcred.objname}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}">
       <include name="*"/>
     </valcredFromFiles>
-    
+
   </target>
 
 	<target name="raw-mgmt-call" depends="-init-dir, -check-std-args">
@@ -1464,10 +1465,10 @@
 	</target>
 
   <target name="-check-std-args">
-    
+
     <fail message="The Ant property 'host' is required but not defined.  This is the hostname or IP address of a DataPower device." unless="host"/>
     <fail message="The Ant property 'uid' is required but not defined.  This is the userid on the DataPower device." unless="uid"/>
-    
+
     <if>
       <not>
         <isset property="pwd"/>
@@ -1478,16 +1479,16 @@
         </input>
       </then>
     </if>
-    
+
     <property name="port" value="5550"/> <!-- Provide a default when this property hasn't been defined before. -->
-    
+
   </target>
-  
-  
+
+
   <target name="-init-dir" depends="clean">
     <mkdir dir="${work.dir}"/>
     <mkdir dir="${schema.dir}"/>
   </target>
-  
+
 
 </project>

--- a/src/dcm-taskdefs.ant.xml
+++ b/src/dcm-taskdefs.ant.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright 2014, 2015 IBM Corp.
-  
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-  
+
    http://www.apache.org/licenses/LICENSE-2.0
-  
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,25 +27,25 @@
   <taskdef name="wdp" classname="com.ibm.dcm.taskWdp" classpath="${dcm.jar}"/>
   <taskdef name="xpath" classname="com.ibm.dcm.taskXpath" classpath="${dcm.jar}"/>
   <taskdef name="forxpath" classname="com.ibm.dcm.taskForXpath" classpath="${dcm.jar}"/>
-  
+
 
 
   <!--
-    
+
     Backup all of the domains on the device in a ZIP format.  Note that this is not
     a secure backup that includes keys/certs.  This is functionally just BackupDomains
     with a list of all the domains on the appliance.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       uid - userid
       pwd - password
       local - filename for ZIP file created by this operation
-      
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="backupDevice">
     <attribute name="local"/>
@@ -57,7 +57,7 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <wdp operation="BackupDevice" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <local>@{local}</local>
@@ -68,27 +68,27 @@
         <ignore-errors>@{ignore-errors}</ignore-errors>
       </wdp>
     </sequential>
-    
+
   </macrodef>
-  
+
   <!--
     Export the specified object (name and class) in a ZIP format.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       uid - userid
       pwd - password
       local - filename for ZIP file created by this operation
       objname - target object's name to be exported
-      objclass - target object's class 
-      
-      
+      objclass - target object's class
+
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors - defaults to false
       refobjs - Include referenced objects? defaults to true
-      reffiles - Include referenced files? defaults to true 
-    
+      reffiles - Include referenced files? defaults to true
+
   -->
 	<macrodef name="exportObject">
     <attribute name="domain"/>
@@ -101,16 +101,16 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-  	
+
     <attribute name="objclass"/>
     <attribute name="objname" />
     <attribute name="refobjs"  default="true"/>
     <attribute name="reffiles" default="true"/>
-  	
+
     <sequential>
       <local name="export_success"/>
       <local name="export_response"/>
-    	
+
       <!-- Export the specified object based on the options given. -->
       <wdp operation="Export" successprop="export_success" responseprop="export_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
           <objects xmlns:soma="http://www.datapower.com/schemas/management">
@@ -124,7 +124,7 @@
           <ignore-errors>@{ignore-errors}</ignore-errors>
           <domain>@{domain}</domain>
       </wdp>
-      
+
       <if>
         <equals arg1="${export_success}" arg2="true"/>
         <then>
@@ -136,13 +136,13 @@
           <fail message="Failed to export object @{objname} of class=@{objclass} from domain @{domain} on @{host}."/>
         </else>
       </if>
-        	
+
     </sequential>
   </macrodef>
 
 	  <!--
 	    Export the specified objects (name and class) in a ZIP format.
-	    
+
 	    Required parameters:
 	      host - hostname or IP address of DataPower device
 	      uid - userid
@@ -154,8 +154,8 @@
 	      port - XML Management Interface port on device (defaults to 5550)
 	      ignore-errors - defaults to false
 	      refobjs - Include referenced objects? defaults to true
-	      reffiles - Include referenced files? defaults to true 
-	    
+	      reffiles - Include referenced files? defaults to true
+
 	  -->
 		<macrodef name="exportObjects">
 	    <attribute name="domain"/>
@@ -168,15 +168,15 @@
 	    <attribute name="dumpoutput" default="false"/>
 	    <attribute name="capturesoma" default=""/>
 	    <attribute name="ignore-errors" default="false"/>
-	  	
+
 	    <attribute name="objects"/>
 	    <attribute name="refobjs"  default="true"/>
 	    <attribute name="reffiles" default="true"/>
-	  	
+
 	    <sequential>
 	      <local name="export_success"/>
 	      <local name="export_response"/>
-	    	
+
 	      <!-- Export the specified object based on the options given. -->
 	      <wdp operation="Export" successprop="export_success" responseprop="export_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
 	          <objects>@{objects}</objects>
@@ -188,7 +188,7 @@
 	          <ignore-errors>@{ignore-errors}</ignore-errors>
 	          <domain>@{domain}</domain>
 	      </wdp>
-	      
+
 	      <if>
 	        <equals arg1="${export_success}" arg2="true"/>
 	        <then>
@@ -200,27 +200,27 @@
 	          <fail message="Failed to export object @{objname} of class=@{objclass} from domain @{domain} on @{host}."/>
 	        </else>
 	      </if>
-	        	
+
 	    </sequential>
 	  </macrodef>
 
-	
+
   <!--
-    
+
     Backup some set of domains in a ZIP format.  Backups up the domain=Xxxx domain plus
     any additional domains in the blank-separated domains=A B ... property.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       uid - userid
       pwd - password
       domains - Blank-separated list of domain names
       local - filename for ZIP file created by this operation
-      
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="backupDomains">
     <attribute name="domain"/>  <!-- first domain to backup -->
@@ -235,11 +235,11 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="domainlist"/>
       <local name="combinedNames"/>
-      
+
       <if>
         <equals arg1="@{saveIfNeeded}" arg2="true"/>
         <then>
@@ -260,12 +260,12 @@
           <property name="combinedNames" value=",@{domain},@{domains},"/>
           <forxpath inprop="domainlist" xpath="/status/DomainStatus[SaveNeeded = 'on' and contains(translate('${combinedNames}', ' ', ','), concat(',', string(Domain), ','))]/Domain">
             <sequential>
-              
+
               <saveDomainUnconditionally host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" domain="@{forxpath}" ignore-errors="@{ignore-errors}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-              
+
             </sequential>
           </forxpath>
-          
+
         </then>
       </if>
       <wdp operation="Backup" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
@@ -279,27 +279,27 @@
         <ignore-errors>@{ignore-errors}</ignore-errors>
       </wdp>
     </sequential>
-    
+
   </macrodef>
-  
+
 
   <!--
-    
-    Check for access to a device using some userid/password.  Returns the firmware 
+
+    Check for access to a device using some userid/password.  Returns the firmware
     version (e.g. XI52.4.0.2.5) in an ant property.  On success the ant property
     (${${versionprop}}) is set to the firmware version.  On failure the ant property
     is either empty or not set.
-    
+
     Required parameters:
     host - hostname or IP address of DataPower device
     uid - userid
     pwd - password
     versionprop - name of Ant property to set with the firmware version
-    
+
     Optional parameters:
     port - XML Management Interface port on device (defaults to 5550)
     ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="checkDeviceAccess">
     <attribute name="host"/>
@@ -312,11 +312,11 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="statusDefault"/>
       <local name="statusDomain"/>
-      
+
       <if>
         <not>
           <isset property="versionprop"/>
@@ -355,22 +355,22 @@
         </then>
       </if>
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Ensure that a file containing the preprocessed XML Management Interface schema is available.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
-    
+
   -->
   <macrodef name="ensureDPSchema">
     <attribute name="host"/>
@@ -386,11 +386,11 @@
     <attribute name="dumpinput" default="false"/>
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
-    
+
     <sequential>
       <local name="fileSavedSchema"/>
       <local name="fileCreatedSchema"/>
-      
+
       <property name="fileSavedSchema" value="@{schemadir}/${@{versionprop}}.dpschema.xml"/>
       <property name="fileCreatedSchema" value="@{workdir}/${@{versionprop}}.dpschema.xml"/>
 <!--
@@ -404,76 +404,76 @@
       <if>
         <available file="${fileSavedSchema}"/>
         <then>
-          
+
           <!-- Use the dpschema file that the user has saved somewhere. -->
           <property name="@{dpschemaFileVbl}" location="${fileSavedSchema}"/>
           <echo>Using ${fileSavedSchema} for @{host}</echo>
-          
+
         </then>
         <else>
           <if>
             <available file="${fileCreatedSchema}"/>
             <then>
-              
+
               <!-- Use the dpschema file that was created earlier during this run. -->
               <property name="@{dpschemaFileVbl}" location="${fileCreatedSchema}"/>
               <echo>Using previously created schema ${fileCreatedSchema} for @{host}</echo>
-              
+
             </then>
             <else>
-              
+
               <!-- Time to do the heavy lifting of downloading the schema files from the host and generating the dpschema file. -->
-              
+
               <dpdownload dir="@{workdir}" dpdir="store:///" filename="xml-mgmt.wsdl"     domain="@{domain}" hostname="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
               <dpdownload dir="@{workdir}" dpdir="store:///" filename="xml-mgmt.xsd"      domain="@{domain}" hostname="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
               <dpdownload dir="@{workdir}" dpdir="store:///" filename="xml-mgmt-base.xsd" domain="@{domain}" hostname="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
               <dpdownload dir="@{workdir}" dpdir="store:///" filename="xml-mgmt-ops.xsd"  domain="@{domain}" hostname="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
               <dpdownload dir="@{workdir}" dpdir="store:///" filename="xml-mgmt-b2b.xsd"  domain="@{domain}" hostname="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}" ignoreerror="true"/>
-              
+
               <nxslt infile="@{workdir}/xml-mgmt.wsdl" outfile="@{workdir}/collected.xml" xsl="@{dcmdir}/src/dpschema-collectxml.xsl"/>
               <nxslt infile="@{workdir}/collected.xml" outfile="${fileCreatedSchema}"     xsl="@{dcmdir}/src/dpschema-reformatsoma.xsl"/>
-              
+
               <property name="@{dpschemaFileVbl}" location="${fileCreatedSchema}"/>
-              
+
               <echo>Using newly created schema ${fileCreatedSchema} for @{host}</echo>
-              
+
               <if>
                 <isfileselected file="@{schemadir}">
                   <writable/>
                 </isfileselected>
                 <then>
-                  
+
                   <copy file="${fileCreatedSchema}" tofile="${fileSavedSchema}"/>
-                  
+
                   <echo>Copied the newly created schema into the schema cache (${fileSavedSchema}).</echo>
-                  
+
                 </then>
               </if>
-              
+
             </else>
           </if>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Create a domain, when it does not exist.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - domain on the device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="createDomain">
     <attribute name="host"/>
@@ -485,23 +485,23 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="create_okay"/>
       <local name="create_response"/>
       <local name="create_success"/>
       <local name="domain_exists"/>
       <local name="domainlist"/>
-      
+
       <getDomainStatus host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" domainsprop="domainlist" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
-      <xpath inprop="domainlist" outprop="domain_exists" 
+
+      <xpath inprop="domainlist" outprop="domain_exists"
         xpath="/status/DomainStatus[Domain='@{domain}']"/>
-      
+
       <if>
         <equals arg1="${domain_exists}" arg2=""/>
         <then>
-          
+
           <wdp operation="SetConfig" successprop="create_success" responseprop="create_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="create_okay">
             <config>
@@ -509,7 +509,7 @@
                 <mAdminState>enabled</mAdminState>
                 <NeighborDomain class="Domain">default</NeighborDomain>
                 <ConfigMode>local</ConfigMode>
-              </Domain>  
+              </Domain>
             </config>
             <hostname>@{host}</hostname>
             <port>@{port}</port>
@@ -517,7 +517,7 @@
             <pwd>@{pwd}</pwd>
             <domain>default</domain>
           </wdp>
-          
+
           <if>
             <and>
               <istrue value="${create_success}"/>
@@ -531,32 +531,32 @@
               <fail message="Failed to create domain @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <echo>Did not create domain @{domain} on @{host} since it already exists.</echo>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Delete a domain, when it exists.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - domain on the device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="deleteDomain">
     <attribute name="host"/>
@@ -568,24 +568,24 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="delete_okay"/>
       <local name="delete_response"/>
       <local name="delete_success"/>
       <local name="domain_exists"/>
       <local name="domainlist"/>
-      
+
       <getDomainStatus host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" domainsprop="domainlist" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
+
       <xpath inprop="domainlist" outprop="domain_exists" xpath="/status/DomainStatus[Domain='@{domain}']"/>
-      
+
       <if>
         <not>
           <equals arg1="${domain_exists}" arg2=""/>
         </not>
         <then>
-          
+
           <wdp operation="DeleteConfig" successprop="delete_success" responseprop="delete_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="delete_okay">
             <classname>Domain</classname>
@@ -596,7 +596,7 @@
             <pwd>@{pwd}</pwd>
             <domain>default</domain>
           </wdp>
-          
+
           <if>
             <and>
               <istrue value="${delete_success}"/>
@@ -610,32 +610,32 @@
               <fail message="Failed to delete domain @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <echo>Did not delete domain @{domain} on @{host} since it does not exist.</echo>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Disable an object.
-    
+
     Required parameters:
     host - hostname or IP address of DataPower device
     domain - domain on the device
     uid - userid
     pwd - password
-    
+
     Optional parameters:
     port - XML Management Interface port on device (defaults to 5550)
     ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="disableObject">
     <attribute name="host"/>
@@ -649,13 +649,13 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="config"/>
       <local name="disable_okay"/>
       <local name="disable_response"/>
       <local name="disable_success"/>
-      
+
       <storexml outprop="config">
         <config>
           &lt;@{objclass} name="@{objname}">
@@ -663,13 +663,13 @@
           &lt;/@{objclass}>
         </config>
       </storexml>
-      
-      <wdp operation="ModifyConfig" domain="@{domain}" hostname="@{host}" uid="@{uid}" pwd="@{pwd}" 
+
+      <wdp operation="ModifyConfig" domain="@{domain}" hostname="@{host}" uid="@{uid}" pwd="@{pwd}"
         successprop="disable_success" responseprop="disable_response" dumpinput="@{dumpoutput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
         xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="disable_okay">
         <wrapper>${config}</wrapper>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${disable_success}"/>
@@ -683,26 +683,26 @@
           <fail message="Failed to disable object @{objclass}/@{objname} in domain @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Disable one or more objects.
-    
+
     Required parameters:
     host - hostname or IP address of DataPower device
     domain - domain on the device
     uid - userid
     pwd - password
-    
+
     Optional parameters:
     port - XML Management Interface port on device (defaults to 5550)
     ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="disableObjects">
     <attribute name="host"/>
@@ -716,27 +716,27 @@
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
     <element name="definition" implicit="yes"/>
-    
+
     <sequential>
       <local name="dcmpolicy"/>
       <local name="config"/>
       <local name="disable_okay"/>
       <local name="disable_response"/>
       <local name="disable_success"/>
-      
+
       <!-- Store the dcm:definition (DCM policy) in a property for easy access. -->
       <storexml outprop="dcmpolicy">
         <definition/> <!-- placeholder for dcm:definition provided as content of <disableObjects> -->
       </storexml>
-      
+
       <!--
         Generate <xxx name="yyy"><mAdminState>disabled</mAdminState></xxx> elements for each object.
       -->
       <nxslt inprop="dcmpolicy" outprop="config" xsl="@{dcmdir}/src/enable-disable-objects.xsl">
         <param ant="'disable'" xsl="newState"/>
       </nxslt>
-      
-      <wdp operation="ModifyConfig" 
+
+      <wdp operation="ModifyConfig"
         successprop="disable_success" responseprop="disable_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
         xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="disable_okay">
         <domain>@{domain}</domain>
@@ -747,7 +747,7 @@
         <local>@{local}</local>
         <wrapper>${config}</wrapper>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${disable_success}"/>
@@ -761,16 +761,16 @@
           <fail message="Failed to disable specified object(s) in domain @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
 
 
   <!--
-    
-    Download target files from filestore 
-    
+
+    Download target files from filestore
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - name of domain
@@ -779,10 +779,10 @@
       local - target directory in local filesystem
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
-    
+
   -->
   <macrodef name="downloadFiles">
     <attribute name="host"/>
@@ -818,16 +818,16 @@
           </wdp>
         </sequential>
       </forxpath>
-      
+
     </sequential>
-    
+
   </macrodef>
 
-	
+
 	<!--
-    
+
     Download a filestore
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - name of domain
@@ -835,10 +835,10 @@
       local - target directory in local filesystem
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
-    
+
   -->
   <macrodef name="downloadFilestore">
     <attribute name="host"/>
@@ -852,13 +852,13 @@
     <attribute name="dumpinput" default="false"/>
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
-    
+
     <sequential>
       <echo>Download all files from @{filestore} to @{local}</echo>
-    	
+
       <local name="rawxml"/>
       <local name="tmp"/>
-      
+
       <!--
         Get the complete listing of all the files and directories in the filestore,
         then convert that XML to a more useful form.
@@ -875,13 +875,13 @@
       </wdp>
       <nxslt inprop="rawxml" outprop="tmp" xsl="@{dcmdir}/src/downloadFilestore.xsl"/>
       <!-- <echo>${tmp}</echo> -->
-      
+
       <forxpath inprop="tmp" xpath="/downloadFilestore/directory" propname="dirname">
         <sequential>
           <mkdir dir="@{local}@{dirname}"/>
         </sequential>
       </forxpath>
-      
+
       <forxpath inprop="tmp" xpath="/downloadFilestore/file" propname="filename">
         <sequential>
           <echo>Downloading @{filestore}@{filename} to @{local}@{filename}</echo>
@@ -896,26 +896,26 @@
           </wdp>
         </sequential>
       </forxpath>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
+
 
   <!--
-    
+
     Enable an object.
-    
+
     Required parameters:
     host - hostname or IP address of DataPower device
     domain - domain on the device
     uid - userid
     pwd - password
-    
+
     Optional parameters:
     port - XML Management Interface port on device (defaults to 5550)
     ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="enableObject">
     <attribute name="host"/>
@@ -929,13 +929,13 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="config"/>
       <local name="enable_okay"/>
       <local name="enable_response"/>
       <local name="enable_success"/>
-      
+
       <storexml outprop="config">
         <config>
           &lt;@{objclass} name="@{objname}">
@@ -943,13 +943,13 @@
           &lt;/@{objclass}>
         </config>
       </storexml>
-      
-      <wdp operation="ModifyConfig" domain="@{domain}" hostname="@{host}" uid="@{uid}" pwd="@{pwd}" 
+
+      <wdp operation="ModifyConfig" domain="@{domain}" hostname="@{host}" uid="@{uid}" pwd="@{pwd}"
         successprop="enable_success" responseprop="enable_response" dumpinput="@{dumpoutput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
         xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="enable_okay">
         <wrapper>${config}</wrapper>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${enable_success}"/>
@@ -963,26 +963,26 @@
           <fail message="Failed to enable object @{objclass}/@{objname} in domain @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Enable one or more objects.
-    
+
     Required parameters:
     host - hostname or IP address of DataPower device
     domain - domain on the device
     uid - userid
     pwd - password
-    
+
     Optional parameters:
     port - XML Management Interface port on device (defaults to 5550)
     ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="enableObjects">
     <attribute name="host"/>
@@ -996,27 +996,27 @@
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
     <element name="definition" implicit="yes"/>
-    
+
     <sequential>
       <local name="dcmpolicy"/>
       <local name="config"/>
       <local name="enable_okay"/>
       <local name="enable_response"/>
       <local name="enable_success"/>
-      
+
       <!-- Store the dcm:definition (DCM policy) in a property for easy access. -->
       <storexml outprop="dcmpolicy">
         <definition/> <!-- placeholder for dcm:definition provided as content of <enableObjects> -->
       </storexml>
-      
+
       <!--
         Generate <xxx name="yyy"><mAdminState>enabled</mAdminState></xxx> elements for each object.
       -->
       <nxslt inprop="dcmpolicy" outprop="config" xsl="@{dcmdir}/src/enable-disable-objects.xsl">
         <param ant="'enable'" xsl="newState"/>
       </nxslt>
-      
-      <wdp operation="ModifyConfig" 
+
+      <wdp operation="ModifyConfig"
         successprop="enable_success" responseprop="enable_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
         xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="enable_okay">
         <domain>@{domain}</domain>
@@ -1027,7 +1027,7 @@
         <local>@{local}</local>
         <wrapper>${config}</wrapper>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${enable_success}"/>
@@ -1041,26 +1041,26 @@
           <fail message="Failed to enable specified object(s) in domain @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Export configuration (as opposed to a domain backup).
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - name of domain
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="exportConfig">
     <attribute name="host"/>
@@ -1079,14 +1079,14 @@
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
     <element name="wrapper"/>
-    
+
     <sequential>
       <local name="export_file"/>
       <local name="export_response"/>
       <local name="status"/>
-      
-      <wdp operation="Export" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}" 
-        responseprop="export_response" 
+
+      <wdp operation="Export" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
+        responseprop="export_response"
         xpathprop="export_file" xpath="string(/env:Envelope/env:Body/soma:response/soma:file)">
         <domain>@{domain}</domain>
         <hostname>@{host}</hostname>
@@ -1102,7 +1102,7 @@
         <ignore-errors>@{ignore-errors}</ignore-errors>
         <wrapper/>
       </wdp>
-      
+
       <if>
         <not>
           <equals arg1="${export_file}" arg2=""/>
@@ -1116,12 +1116,12 @@
           <fail message="Failed to export specified object(s) in domain @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Firmware rollback to previous version.
   -->
@@ -1134,17 +1134,17 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="success-update"/>
-      
+
       <!-- Rollback to previous firmware (and other aspects of file system!). -->
       <wdp operation="FirmwareRollback" successprop="success-update" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <hostname>@{host}</hostname>
         <uid>@{uid}</uid>
         <pwd>@{pwd}</pwd>
       </wdp>
-      
+
       <if>
         <isset property="success-update"/>
         <then>
@@ -1154,9 +1154,9 @@
           <fail message="Failed to rollback the firmware on @{host}"/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
 
 
@@ -1173,21 +1173,21 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="basename-scryptfile"/>
       <local name="dirname-scryptfile"/>
       <local name="success-update"/>
-      
+
       <basename property="basename-scryptfile" file="@{scryptfile}"/>
       <dirname property="dirname-scryptfile" file="@{scryptfile}"/>
-      
+
       <!-- Upload the firmware update file. -->
       <echo>Uploading the firmware update</echo>
       <dpupload dir="${dirname-scryptfile}" target="image:///" domain="default" host="@{host}" port="@{port}" uid="@{uid}" pwd="@{pwd}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <include name="${basename-scryptfile}"/>
       </dpupload>
-      
+
       <!-- Update that puppy. -->
       <echo>Applying the firmware update, followed automatically by a reboot of the appliance.  This requires a few minutes to complete.</echo>
       <wdp operation="BootUpdate" successprop="success-update" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
@@ -1196,7 +1196,7 @@
         <uid>@{uid}</uid>
         <pwd>@{pwd}</pwd>
       </wdp>
-      
+
       <if>
         <isset property="success-update"/>
         <then>
@@ -1206,24 +1206,24 @@
           <fail message="Failed to update the firmware on @{host} to @{scryptfile}"/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
 
 
   <!--
-    
+
     Fetch the current status of all the domains.  This is useful for when you want to check whether
     a domain exists, whether it needs to be saved, and whether debug logging, probe, etc. are enabled
     in the domain. If you want to know whether a domain is enabled/up, though, this isn't the task.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       uid - userid
       pwd - password
       domainsprop - name of Ant property to set with the XML for the domains
-      
+
     The domainprop contains XML like this:
     <status>
       <DomainStatus>
@@ -1240,11 +1240,11 @@
         ...
       </DomainStatus>
     </status>
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="getDomainStatus">
     <attribute name="host"/>
@@ -1256,7 +1256,7 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="status"/>
 
@@ -1271,12 +1271,12 @@
         <return antprop="@{domainsprop}" somaprop="status"/>
       </wdp>
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    Determine the operational state (up/down) of a service 
+    Determine the operational state (up/down) of a service
   -->
   <macrodef name="getServiceStatus">
     <attribute name="host" />
@@ -1292,12 +1292,12 @@
     <attribute name="dumpoutput" default="false" />
     <attribute name="capturesoma"/>
     <attribute name="ignore-errors" default="false" />
-    
+
     <sequential>
       <local name="capture"/>
       <local name="success" />
       <local name="opstate" />
-      
+
       <wdp operation="GetObjectStatus" successprop="success" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <hostname>@{host}</hostname>
         <uid>@{uid}</uid>
@@ -1305,7 +1305,7 @@
         <domain>@{domain}</domain>
         <return antprop="status" somaprop="@{servicetype}.@{servicename}" />
       </wdp>
-      
+
       <if>
         <and>
           <isset property="status" />
@@ -1315,7 +1315,7 @@
           <xpath inprop="status" outprop="opstate" xpath="/ObjectStatus/OpState/text()"/>
           <echo message="@{servicetype}.@{servicename} OpState: ${opstate}" />
           <property name="@{outputprop}.opstate" value="${opstate}" />
-          
+
         </then>
         <else>
           <if>
@@ -1327,13 +1327,13 @@
               <fail message="Error getting service status for service @{servicetype}.@{servicename} in @{domain} on @{host}." />
             </else>
           </if>
-          
+
         </else>
       </if>
     </sequential>
   </macrodef>
-  
-  
+
+
   <!--
     Create/overwrite an ID Cred and key/cert files and objects.
   -->
@@ -1351,7 +1351,7 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="basename"/>
       <local name="basename-no-ext"/>
@@ -1360,16 +1360,16 @@
       <local name="success-create-cert"/>
       <local name="success-create-idcred"/>
       <local name="success-create-key"/>
-<!--      
+<!--
       <echo>p12file=@{p12file}</echo>
       <echo>p12pwd=@{p12pwd}</echo>
       <echo>objname=@{objname}</echo>
       <echo>ignoreexpiration=@{ignoreexpiration}</echo>
--->      
+-->
       <basename property="basename" file="@{p12file}"/>
       <basename property="basename-no-ext" file="@{p12file}" suffix=".p12"/>
       <dirname property="dirname" file="@{p12file}"/>
-      
+
       <!--
         Okay, we now have a #PKCS12 file containing a key/cert pair plus the password for the file.
         Upload the file regardless of whether it may already exist.
@@ -1377,7 +1377,7 @@
       <dpupload dir="${dirname}" target="cert:///" domain="@{domain}" url="https://@{host}:@{port}/service/mgmt/current" uid="@{uid}" pwd="@{pwd}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <include name="${basename}"/>
       </dpupload>
-      
+
       <!-- Create a Crypto Certficate object to wrap the #PKCS12 file. -->
       <wdp operation="SetConfig" successprop="success-create-cert" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <config>
@@ -1394,14 +1394,14 @@
         <pwd>@{pwd}</pwd>
         <domain>@{domain}</domain>
       </wdp>
-      
+
       <if>
         <and>
           <isset property="success-create-cert"/>
           <equals arg1="${success-create-cert}" arg2="true"/>
         </and>
         <then>
-          
+
           <!-- Create a Crypto Key object to wrap the #PKCS12 file. -->
           <wdp operation="SetConfig" successprop="success-create-key" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
             <config>
@@ -1417,14 +1417,14 @@
             <pwd>@{pwd}</pwd>
             <domain>@{domain}</domain>
           </wdp>
-          
+
           <if>
             <and>
               <isset property="success-create-key"/>
               <equals arg1="${success-create-key}" arg2="true"/>
             </and>
             <then>
-              
+
               <!-- Create the idcred object. -->
               <wdp operation="SetConfig" successprop="success-create-idcred" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
                 <config>
@@ -1439,7 +1439,7 @@
                 <pwd>@{pwd}</pwd>
                 <domain>@{domain}</domain>
               </wdp>
-              
+
               <if>
                 <and>
                   <isset property="success-create-idcred"/>
@@ -1452,24 +1452,24 @@
                   <fail message="Failed to create the ID Credential object @{objname}"/>
                 </else>
               </if>
-              
+
             </then>
             <else>
               <fail message="Failed to create the Crypto Key object ${basename-no-ext}"/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <fail message="Failed to create the Crypto Certificate object ${basename-no-ext}"/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Create/overwrite an ID Cred and key/cert files and objects.
   -->
@@ -1489,7 +1489,7 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="basename-cert"/>
       <local name="basename-key"/>
@@ -1499,19 +1499,19 @@
       <local name="success-create-cert"/>
       <local name="success-create-idcred"/>
       <local name="success-create-key"/>
-<!--      
+<!--
       <echo>certfile=@{certfile}</echo>
       <echo>certpwd=@{certpwd}</echo>
       <echo>keyfile=@{keyfile}</echo>
       <echo>keypwd=@{keypwd}</echo>
       <echo>objname=@{objname}</echo>
       <echo>ignoreexpiration=@{ignoreexpiration}</echo>
--->      
+-->
       <basename property="basename-cert" file="@{certfile}"/>
       <basename property="basename-key" file="@{keyfile}"/>
       <dirname property="dirname-cert" file="@{certfile}"/>
       <dirname property="dirname-key" file="@{keyfile}"/>
-      
+
       <!--
         Okay, we now have key and certificate files containing a key/cert pair plus passwords for the files.
         Upload the files regardless of whether they may already exist.
@@ -1519,16 +1519,16 @@
       <if>
         <equals arg1="${dirname-cert}" arg2="${dirname-key}"/>
         <then>
-          
+
           <!-- Upload the two files from the same source directory. -->
           <dpupload dir="${dirname-cert}" target="cert:///" domain="@{domain}" url="https://@{host}:@{port}/service/mgmt/current" uid="@{uid}" pwd="@{pwd}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
             <include name="${basename-cert}"/>
             <include name="${basename-key}"/>
           </dpupload>
-          
+
         </then>
         <else>
-          
+
           <!-- Upload the two files from different source directories. -->
           <dpupload dir="${dirname-cert}" target="cert:///" domain="@{domain}" url="https://@{host}:@{port}/service/mgmt/current" uid="@{uid}" pwd="@{pwd}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
             <include name="${basename-cert}"/>
@@ -1536,10 +1536,10 @@
           <dpupload dir="${dirname-key}" target="cert:///" domain="@{domain}" url="https://@{host}:@{port}/service/mgmt/current" uid="@{uid}" pwd="@{pwd}" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
             <include name="${basename-key}"/>
           </dpupload>
-          
+
         </else>
       </if>
-      
+
       <!-- Create a Crypto Certficate object to wrap the certificate file. -->
       <wdp operation="SetConfig" successprop="success-create-cert" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <config>
@@ -1556,14 +1556,14 @@
         <pwd>@{pwd}</pwd>
         <domain>@{domain}</domain>
       </wdp>
-      
+
       <if>
         <and>
           <isset property="success-create-cert"/>
           <equals arg1="${success-create-cert}" arg2="true"/>
         </and>
         <then>
-          
+
           <!-- Create a Crypto Key object to wrap the key file. -->
           <wdp operation="SetConfig" successprop="success-create-key" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
             <config>
@@ -1579,14 +1579,14 @@
             <pwd>@{pwd}</pwd>
             <domain>@{domain}</domain>
           </wdp>
-          
+
           <if>
             <and>
               <isset property="success-create-key"/>
               <equals arg1="${success-create-key}" arg2="true"/>
             </and>
             <then>
-              
+
               <!-- Create the idcred object. -->
               <wdp operation="SetConfig" successprop="success-create-idcred" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
                 <config>
@@ -1601,7 +1601,7 @@
                 <pwd>@{pwd}</pwd>
                 <domain>@{domain}</domain>
               </wdp>
-              
+
               <if>
                 <and>
                   <isset property="success-create-idcred"/>
@@ -1614,24 +1614,24 @@
                   <fail message="Failed to create the ID Credential object @{objname}"/>
                 </else>
               </if>
-              
+
             </then>
             <else>
               <fail message="Failed to create the Crypto Key object ${basename-key}"/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <fail message="Failed to create the Crypto Certificate object ${basename-cert}"/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Import some DataPower export, optionally applying deployment policies in the process.
   -->
@@ -1642,6 +1642,7 @@
     <attribute name="pwd"/>
     <attribute name="domain"/>
     <attribute name="inputfile"/> <!-- name of DataPower export file -->
+    <attribute name="ignoreError" default=""/> <!-- SOMA error to ignore - Note: Can't be empty -->
     <attribute name="dcmdir"/> <!-- directory where DCM is found -->
     <attribute name="workdir"/> <!-- tmpdir where a directory can be created, if necessary -->
     <attribute name="dumpinput" default="false"/>
@@ -1653,14 +1654,14 @@
     <attribute name="overwrite-objects" default="true"/>
     <attribute name="changes" default=""/> <!-- Alternative to passing in XML content -->
     <element name="definition" implicit="yes" optional="yes"/>
-    
+
     <sequential> <!-- permit declaring some variables local in scope. -->
       <local name="dcmdefinition"/>
       <local name="import_errors"/>
       <local name="import_basename"/>
       <local name="import_response"/>
       <local name="import_success"/>
-      
+
       <!-- Store the dcm:definition (DCM policy) in a property for easy access. -->
       <if>
         <equals arg1="@{changes}" arg2=""/>
@@ -1678,17 +1679,17 @@
       <nxslt infile="@{workdir}/1_raw-policy.xml" outfile="@{workdir}/2_included_policies.xml" xsl="@{dcmdir}/src/process-includes.xsl"/>
       <nxslt infile="@{workdir}/2_included_policies.xml" outfile="@{workdir}/3_expanded-deployment-policies.xml" xsl="@{dcmdir}/src/expand-black-white-modify.xsl"/>
       <nxslt infile="@{workdir}/3_expanded-deployment-policies.xml" outfile="@{workdir}/4_gathered-deployment-policies.xml" xsl="@{dcmdir}/src/write-deployment-policy.xsl"/>
-      
+
       <basename file="@{inputfile}" property="import_basename"/>
       <loadfile srcfile="@{workdir}/2_included_policies.xml" property="dcmdefinition"/>
       <rewriteExport inputfile="@{inputfile}" outputfile="@{workdir}/${import_basename}"
         dcmdir="@{dcmdir}" workdir="@{workdir}" changes="${dcmdefinition}"/>
-      
+
       <!--
         Import the (possibly rewritten) DataPower export file.
       -->
       <echo>Importing @{inputfile} into domain @{domain} on @{host}.</echo>
-      <wdp operation="ImportConfig" responseprop="import_response" successprop="import_success" xpathprop="import_errors" 
+      <wdp operation="ImportConfig" responseprop="import_response" successprop="import_success" xpathprop="import_errors"
         xpath="/env:Envelope/env:Body/soma:response/soma:import/import-results/exec-script-results/cfg-result[@status!='SUCCESS'] | /env:Envelope/env:Body/soma:response/soma:import/import-results/file-copy-log/file-result[not(@result='OK' or @result='ignored')] | /env:Envelope/env:Body/soma:response/soma:result"
         dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <domain>@{domain}</domain>
@@ -1715,16 +1716,31 @@
         </then>
         <else>
           <echo>Raw response to importing @{inputfile}</echo>
-          <echo>${import_response}</echo>
-          <fail message="Failed to import @{inputfile} into domain @{domain} on @{host}."/>
+          <echo>Import Response: ${import_response}</echo>
+          <echo>Import Error(s): '${import_errors}'</echo>
+          <echo>Ignore Error Regex: '@{ignoreError}'</echo>
+          <!-- If ignoreError regex specified, try to ignore given SOMA error -->
+          <if>
+            <and>
+              <length string="@{ignoreError}" when="greater" length="0"/>
+              <matches string="${import_errors}" pattern="@{ignoreError}"/>
+            </and>
+            <then>
+              <echo>Regex successfully matched. Ignoring import error...</echo>
+              <echo>Successfully imported @{inputfile} into domain @{domain} on @{host}.</echo>
+            </then>
+            <else>
+              <fail message="Failed to import @{inputfile} into domain @{domain} on @{host}."/>
+            </else>
+          </if>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Import some DataPower export, applying a built-in deployment policy in the process.
   -->
@@ -1735,6 +1751,7 @@
     <attribute name="pwd"/>
     <attribute name="domain"/>
     <attribute name="inputfile"/> <!-- name of DataPower export file -->
+    <attribute name="ignoreError" default=""/> <!-- SOMA error to ignore - Note: Can't be empty -->
     <attribute name="dpo"/> <!-- name of deployment policy object -->
     <attribute name="dcmdir"/> <!-- directory where DCM is found -->
     <attribute name="workdir"/> <!-- tmpdir where a directory can be created, if necessary -->
@@ -1745,17 +1762,17 @@
     <attribute name="rewrite-local" default="true"/>
     <attribute name="overwrite-files" default="true"/>
     <attribute name="overwrite-objects" default="true"/>
-    
+
     <sequential> <!-- permit declaring some variables local in scope. -->
       <local name="import_errors"/>
       <local name="import_response"/>
       <local name="import_success"/>
-      
+
       <!--
         Import the DataPower export file.
       -->
       <echo>Importing @{inputfile} into domain @{domain} on @{host}.</echo>
-      <wdp operation="ImportConfig" responseprop="import_response" successprop="import_success" xpathprop="import_errors" 
+      <wdp operation="ImportConfig" responseprop="import_response" successprop="import_success" xpathprop="import_errors"
         xpath="/env:Envelope/env:Body/soma:response/soma:import/import-results/exec-script-results/cfg-result[@status!='SUCCESS'] | /env:Envelope/env:Body/soma:response/soma:import/import-results/file-copy-log/file-result[not(@result='OK' or @result='ignored')] | /env:Envelope/env:Body/soma:response/soma:result"
         dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <domain>@{domain}</domain>
@@ -1782,20 +1799,35 @@
         </then>
         <else>
           <echo>Raw response to importing @{inputfile}</echo>
-          <echo>${import_response}</echo>
-          <fail message="Failed to import @{inputfile} into domain @{domain} on @{host}."/>
+          <echo>Import Response: ${import_response}</echo>
+          <echo>Import Error(s): '${import_errors}'</echo>
+          <echo>Ignore Error Regex: '@{ignoreError}'</echo>
+          <!-- If ignoreError regex specified, try to ignore given SOMA error -->
+          <if>
+            <and>
+              <length string="@{ignoreError}" when="greater" length="0"/>
+              <matches string="${import_errors}" pattern="@{ignoreError}"/>
+            </and>
+            <then>
+              <echo>Regex successfully matched. Ignoring import error...</echo>
+              <echo>Successfully imported @{inputfile} into domain @{domain} on @{host}.</echo>
+            </then>
+            <else>
+              <fail message="Failed to import @{inputfile} into domain @{domain} on @{host}."/>
+            </else>
+          </if>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
 
 
   <!--
-    
+
     Listing of a filestore
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - name of domain
@@ -1803,11 +1835,11 @@
       listprop - name of Ant property where the listing should be stored
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="listFilestore">
     <attribute name="host"/>
@@ -1821,9 +1853,9 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
-      
+
       <wdp operation="GetFilestore" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <domain>@{domain}</domain>
         <hostname>@{host}</hostname>
@@ -1834,9 +1866,9 @@
         <ignore-errors>@{ignore-errors}</ignore-errors>
         <return antprop="@{listprop}" somaprop="location"/>
       </wdp>
-      
+
     </sequential>
-    
+
   </macrodef>
 
 
@@ -1862,7 +1894,7 @@
     <attribute name="ignore-errors" default="false"/>
     <attribute name="changes" default=""/> <!-- Alternative to passing in XML content -->
     <element name="definition" implicit="yes" optional="yes"/>
-    
+
     <sequential>
       <local name="config"/>
       <local name="get_response"/>
@@ -1871,12 +1903,12 @@
       <local name="schema_file"/>
       <local name="set_okay"/>
       <local name="set_response"/>
-      
+
       <!-- We'll need the preprocessed schema to make our best effort to ensure that the request is schema-compliant. -->
       <ensureDPSchema host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" versionprop="@{versionprop}"
         domain="@{domain}" dcmdir="@{dcmdir}" schemadir="@{schemadir}" workdir="@{workdir}" dpschemaFileVbl="schema_file"
         dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
+
       <!-- Get the configuration of the existing object. -->
       <wdp operation="GetConfig" responseprop="get_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <domain>@{domain}</domain>
@@ -1888,9 +1920,9 @@
         <objname>@{existing-name}</objname>
         <return antprop="config" somaprop="config"/>
       </wdp>
-      
+
       <!-- <echo>::: getConfig returned ${config}</echo> -->
-      
+
       <if>
         <!-- ${config} != '' and ${config} != '<objs></objs>' -->
         <and>
@@ -1902,14 +1934,14 @@
           </not>
         </and>
         <then>
-          
+
           <!-- Store any changes in a file, so we can pass them to the stylesheet.-->
           <property name="oc_file" value="@{workdir}/object-create.xml"/>
           <storexml outfile="${oc_file}"><changes><definition/></changes></storexml>
-          
+
           <!-- <echo>::: oc_file = ${oc_file}</echo> -->
           <!-- <echo>::: schema_file = ${schema_file}</echo> -->
-          
+
           <!--
             Create the XML for the new object, including its new name, based on the XML from
             the existing object plus any specified changes.  Ensure the resulting XML is as
@@ -1920,9 +1952,9 @@
             <param xsl="schema-url" ant="${schema_file}"/>
             <param xsl="new-name" ant="@{new-name}"/>
           </nxslt>
-          
+
           <!-- <echo>::: new_config = ${new_config}</echo> -->
-          
+
           <!-- Create the new object. -->
           <wdp operation="SetConfig" responseprop="set_response"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="set_okay"
@@ -1934,10 +1966,10 @@
             <pwd>@{pwd}</pwd>
             <config>${new_config}</config>
           </wdp>
-          
+
           <!-- <echo>::: set_okay = ${set_okay}</echo> -->
           <!-- <echo>::: set_response = ${set_response}</echo> -->
-          
+
           <if>
             <equals arg1="${set_okay}" arg2="OK"/>
             <then>
@@ -1948,19 +1980,19 @@
               <fail message="Failed to create @{class}/@{new-name} in @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <echo>Raw response for dcm:object-create getConfig: ${get_response}</echo>
           <fail message="Failed to get the configuration of @{class}/@{existing-name} in @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Create an object based on inline XML.
   -->
@@ -1988,13 +2020,13 @@
       <local name="schema_file"/>
       <local name="set_okay"/>
       <local name="set_response"/>
-      
+
       <!-- We'll need the preprocessed schema to make our best effort to ensure that the request is schema-compliant. -->
       <ensureDPSchema host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" versionprop="@{versionprop}"
         domain="@{domain}" dcmdir="@{dcmdir}" schemadir="@{schemadir}" workdir="@{workdir}" dpschemaFileVbl="schema_file"
         dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
 
-      <!-- 
+      <!--
         Copy the inline definition to a file, wrapping it in an dcm:object-create
         element for the benefit of the object-modify stylesheet.
       -->
@@ -2003,15 +2035,15 @@
 
       <!-- <echo>::: oc_file = ${oc_file}</echo> -->
       <!-- <echo>::: schema_file = ${schema_file}</echo> -->
-      
+
       <nxslt infile="${oc_file}" outprop="new_config" xsl="@{dcmdir}/src/object-modify.xsl">
         <param xsl="input-url" ant="${oc_file}"/>
         <param xsl="schema-url" ant="${schema_file}"/>
         <!-- <param xsl="new-name" ant="{$oc/@newname}"/> -->
       </nxslt>
-      
+
       <!-- <echo>::: new_config = ${new_config}</echo> -->
-      
+
       <!-- Create the new object. -->
       <wdp operation="SetConfig" responseprop="set_response"
         xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="set_okay"
@@ -2023,10 +2055,10 @@
         <pwd>@{pwd}</pwd>
         <config>${new_config}</config>
       </wdp>
-      
+
       <!-- <echo>::: set_okay = ${set_okay}</echo> -->
       <!-- <echo>::: set_response = ${set_response}</echo> -->
-      
+
       <if>
         <equals arg1="${set_okay}" arg2="OK"/>
         <then>
@@ -2038,10 +2070,10 @@
         </else>
       </if>
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Create an object based on an object in an export file.
   -->
@@ -2065,7 +2097,7 @@
     <attribute name="ignore-errors" default="false"/>
     <attribute name="changes" default=""/> <!-- Alternative to passing in XML content -->
     <element name="definition" implicit="yes" optional="yes"/>
-    
+
     <sequential>
       <local name="config"/>
       <local name="file_base_name"/>
@@ -2077,48 +2109,48 @@
       <local name="schema_file"/>
       <local name="set_okay"/>
       <local name="set_response"/>
-      
+
       <!-- We'll need the preprocessed schema to make our best effort to ensure that the request is schema-compliant. -->
       <ensureDPSchema host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" versionprop="@{versionprop}"
         domain="@{domain}" dcmdir="@{dcmdir}" schemadir="@{schemadir}" workdir="@{workdir}" dpschemaFileVbl="schema_file"
         dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
+
       <!-- Determine the file extension. -->
       <basename property="file_base_name" file="@{export}"/>
       <condition property="is_zip">
         <matches pattern=".+\.[zZ][iI][pP]$" string="${file_base_name}"/>
       </condition>
-      
+
       <!-- <echo>### file_base_name=${file_base_name}, is_zip=${is_zip}</echo> -->
-      
+
       <property name="private_dir" value="@{workdir}/export_${file_base_name}"/>
       <property name="private_xml" value="${private_dir}/export.xml"/>
-      
+
       <!-- <echo>### private_dir=${private_dir}</echo> -->
       <!-- <echo>### private_xml=${private_xml}</echo> -->
-      
+
       <if>
         <istrue value="${is_zip}"/>
         <then>
-          
+
           <!-- Unzip .zip files so we can access their export.xml. -->
           <mkdir dir="${private_dir}"/>
           <unzip src="@{export}" dest="${private_dir}"/>
-          
+
           <!-- Extract the configuration of the existing object. -->
           <xpath infile="${private_xml}" outprop="config" xpath="/datapower-configuration/configuration/*[name()='@{class}']" xpathType="node"/>
-          
+
         </then>
         <else>
-          
+
           <!-- Extract the configuration of the existing object. -->
           <xpath infile="@{export}" outprop="config" xpath="/datapower-configuration/configuration/*[name()='@{class}']" xpathType="node"/>
-          
+
         </else>
       </if>
-      
+
       <!-- <echo>### config=${config}</echo> -->
-      
+
       <if>
         <!-- ${config} != '' and ${config} != '<objs></objs>' -->
         <and>
@@ -2130,22 +2162,22 @@
           </not>
         </and>
         <then>
-          
+
           <!-- Store any changes in a file, so we can pass them to the stylesheet.-->
           <property name="oc_file" value="@{workdir}/object-create.xml"/>
           <storexml outfile="${oc_file}"><changes><definition/></changes></storexml>
-          
+
           <!-- <echo>::: oc_file = ${oc_file}</echo> -->
           <!-- <echo>::: schema_file = ${schema_file}</echo> -->
-          
+
           <nxslt inprop="config" outprop="new_config" xsl="@{dcmdir}/src/object-modify.xsl">
             <param xsl="input-url" ant="${oc_file}"/>
             <param xsl="schema-url" ant="${schema_file}"/>
             <param xsl="new-name" ant="@{new-name}"/>
           </nxslt>
-          
+
           <!-- <echo>::: new_config = ${new_config}</echo> -->
-          
+
           <!-- Create the new object. -->
           <wdp operation="SetConfig" responseprop="set_response"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="set_okay"
@@ -2157,10 +2189,10 @@
             <pwd>@{pwd}</pwd>
             <config>${new_config}</config>
           </wdp>
-          
+
           <!-- <echo>::: set_okay = ${set_okay}</echo> -->
           <!-- <echo>::: set_response = ${set_response}</echo> -->
-          
+
           <if>
             <equals arg1="${set_okay}" arg2="OK"/>
             <then>
@@ -2171,18 +2203,18 @@
               <fail message="Failed to create @{class}/@{new-name} in @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <fail message="Failed to get the configuration of @{class}/@{existing-name} in @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Delete an object.
   -->
@@ -2204,7 +2236,7 @@
     <sequential>
       <local name="delete_success"/>
       <local name="delete_response"/>
-      
+
       <!-- Delete the existing object. -->
       <wdp operation="DeleteConfig" responseprop="delete_response" successprop="delete_success" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <domain>@{domain}</domain>
@@ -2215,10 +2247,10 @@
         <classname>@{class}</classname>
         <objname>@{name}</objname>
       </wdp>
-      
+
       <!-- <echo>::: delete_success = ${delete_success}</echo> -->
       <!-- <echo>::: delete_response = ${delete_response}</echo> -->
-      
+
       <if>
         <istrue value="${delete_success}"/>
         <then>
@@ -2229,12 +2261,12 @@
           <fail message="Failed to delete @{class}/@{name} in @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Modify an object based on inline XML changes.
   -->
@@ -2256,7 +2288,7 @@
     <attribute name="ignore-errors" default="false"/>
     <attribute name="changes" default=""/> <!-- Alternative to passing in XML content -->
     <element name="definition" implicit="yes" optional="yes"/>
-    
+
     <sequential>
       <local name="config"/>
       <local name="get_response"/>
@@ -2265,12 +2297,12 @@
       <local name="schema_file"/>
       <local name="set_okay"/>
       <local name="set_response"/>
-      
+
       <!-- We'll need the preprocessed schema to make our best effort to ensure that the request is schema-compliant. -->
       <ensureDPSchema host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" versionprop="@{versionprop}"
         domain="@{domain}" dcmdir="@{dcmdir}" schemadir="@{schemadir}" workdir="@{workdir}" dpschemaFileVbl="schema_file"
         dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
+
       <!-- Get the configuration of the existing object. -->
       <wdp operation="GetConfig" responseprop="get_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <domain>@{domain}</domain>
@@ -2282,9 +2314,9 @@
         <objname>@{name}</objname>
         <return antprop="config" somaprop="config"/>
       </wdp>
-      
+
       <!-- <echo>::: getConfig returned ${config}</echo> -->
-      
+
       <if>
         <!-- ${config} != '' and ${config} != '<objs></objs>' -->
         <and>
@@ -2296,20 +2328,20 @@
           </not>
         </and>
         <then>
-          
+
           <property name="om_file" value="@{workdir}/object-modify.xml"/>
           <storexml outfile="${om_file}"><changes><definition/></changes></storexml>
-          
+
           <!-- <echo>::: om_file = ${om_file}</echo> -->
           <!-- <echo>::: schema_file = ${schema_file}</echo> -->
-          
+
           <nxslt inprop="config" outprop="new_config" xsl="@{dcmdir}/src/object-modify.xsl">
             <param xsl="input-url" ant="${om_file}"/>
             <param xsl="schema-url" ant="${schema_file}"/>
           </nxslt>
-          
+
           <!-- <echo>::: new_config = ${new_config}</echo> -->
-          
+
           <!-- Create the new object. -->
           <wdp operation="SetConfig" responseprop="set_response"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="set_okay"
@@ -2321,10 +2353,10 @@
             <pwd>@{pwd}</pwd>
             <config>${new_config}</config>
           </wdp>
-          
+
           <!-- <echo>::: set_okay = ${set_okay}</echo> -->
           <!-- <echo>::: set_response = ${set_response}</echo> -->
-          
+
           <if>
             <equals arg1="${set_okay}" arg2="OK"/>
             <then>
@@ -2335,34 +2367,34 @@
               <fail message="Failed to create @{class}/@{name} in @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <echo>Raw response for dcm:object-modify getConfig: ${get_response}</echo>
           <fail message="Failed to get the configuration of @{class}/@{name} in @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Quiesce all the services in a domain, when it exists.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - domain on the device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       timeout - number of seconds to wait for existing transactions to end
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="quiesceDomain">
     <attribute name="host"/>
@@ -2375,24 +2407,24 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="quiesce_okay"/>
       <local name="quiesce_response"/>
       <local name="quiesce_success"/>
       <local name="domain_exists"/>
       <local name="domainlist"/>
-      
+
       <getDomainStatus host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" domainsprop="domainlist" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
+
       <xpath inprop="domainlist" outprop="domain_exists" xpath="/status/DomainStatus[Domain='@{domain}']"/>
-      
+
       <if>
         <not>
           <equals arg1="${domain_exists}" arg2=""/>
         </not>
         <then>
-          
+
           <wdp operation="QuiesceDomain" successprop="quiesce_success" responseprop="quiesce_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="quiesce_okay">
             <hostname>@{host}</hostname>
@@ -2402,7 +2434,7 @@
             <domain>@{domain}</domain>
             <timeout>@{timeout}</timeout>
           </wdp>
-          
+
           <if>
             <and>
               <istrue value="${quiesce_success}"/>
@@ -2416,18 +2448,18 @@
               <fail message="Failed to quiesce domain @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <echo>Did not quiesce domain @{domain} on @{host} since it does not exist.</echo>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Quiesce a service
   -->
@@ -2444,7 +2476,7 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma"/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="quiesce_okay"/>
       <local name="quiesce_response"/>
@@ -2514,12 +2546,12 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma"/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="removecheckpoint_okay"/>
       <local name="removecheckpoint_response"/>
       <local name="removecheckpoint_success"/>
-      
+
       <wdp operation="RemoveCheckpoint" successprop="removecheckpoint_success" responseprop="removecheckpoint_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}"
         xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="removecheckpoint_okay" capturesoma="@{capturesoma}">
         <hostname>@{host}</hostname>
@@ -2529,7 +2561,7 @@
         <domain>@{domain}</domain>
         <name>@{checkpoint-name}</name>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${removecheckpoint_success}"/>
@@ -2545,22 +2577,22 @@
       </if>
     </sequential>
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Reset a domain conventionally, using ResetDomain, when the domain exists.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - domain on the device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="resetDomainConventionally">
     <attribute name="host"/>
@@ -2572,25 +2604,25 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="reset_okay"/>
       <local name="reset_response"/>
       <local name="reset_success"/>
       <local name="domain_exists"/>
       <local name="domainlist"/>
-      
+
       <getDomainStatus host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" domainsprop="domainlist" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
-      <xpath inprop="domainlist" outprop="domain_exists" 
+
+      <xpath inprop="domainlist" outprop="domain_exists"
         xpath="/status/DomainStatus[Domain='@{domain}']"/>
-      
+
       <if>
         <not>
           <equals arg1="${domain_exists}" arg2=""/>
         </not>
         <then>
-          
+
           <wdp operation="ResetDomain" successprop="reset_success" responseprop="reset_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="reset_okay">
             <hostname>@{host}</hostname>
@@ -2599,7 +2631,7 @@
             <pwd>@{pwd}</pwd>
             <domain>@{domain}</domain>
           </wdp>
-          
+
           <if>
             <and>
               <istrue value="${reset_success}"/>
@@ -2613,32 +2645,32 @@
               <fail message="Failed to reset domain @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <echo>Did not reset domain @{domain} on @{host} since it does not exist.</echo>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Reset a domain by deleting it (when it exists) and then (re)creating it.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - domain on the device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="resetDomainDeleteCreate">
     <attribute name="host"/>
@@ -2650,7 +2682,7 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="create_okay"/>
       <local name="create_response"/>
@@ -2660,10 +2692,10 @@
       <local name="delete_success"/>
       <local name="domain_exists"/>
       <local name="domainlist"/>
-      
+
       <getDomainStatus host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" domainsprop="domainlist" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
-      <xpath inprop="domainlist" outprop="domain_exists" 
+
+      <xpath inprop="domainlist" outprop="domain_exists"
         xpath="/status/DomainStatus[Domain='@{domain}']"/>
 
       <if>
@@ -2671,7 +2703,7 @@
           <equals arg1="${domain_exists}" arg2=""/>
         </not>
         <then>
-          
+
           <wdp operation="DeleteConfig" successprop="delete_success" responseprop="delete_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="delete_okay">
             <classname>Domain</classname>
@@ -2682,7 +2714,7 @@
             <pwd>@{pwd}</pwd>
             <domain>default</domain>
           </wdp>
-          
+
           <if>
             <and>
               <istrue value="${delete_success}"/>
@@ -2694,7 +2726,7 @@
               <fail message="Failed to delete domain @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
       </if>
 
@@ -2705,7 +2737,7 @@
             <mAdminState>enabled</mAdminState>
             <NeighborDomain class="Domain">default</NeighborDomain>
             <ConfigMode>local</ConfigMode>
-          </Domain>  
+          </Domain>
         </config>
         <hostname>@{host}</hostname>
         <port>@{port}</port>
@@ -2713,7 +2745,7 @@
         <pwd>@{pwd}</pwd>
         <domain>default</domain>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${create_success}"/>
@@ -2727,26 +2759,26 @@
           <fail message="Failed to create domain @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Restart a domain, when it exists.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - domain on the device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="restartDomain">
     <attribute name="host"/>
@@ -2758,25 +2790,25 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="restart_okay"/>
       <local name="restart_response"/>
       <local name="restart_success"/>
       <local name="domain_exists"/>
       <local name="domainlist"/>
-      
+
       <getDomainStatus host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" domainsprop="domainlist" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
-      <xpath inprop="domainlist" outprop="domain_exists" 
+
+      <xpath inprop="domainlist" outprop="domain_exists"
         xpath="/status/DomainStatus[Domain='@{domain}']"/>
-      
+
       <if>
         <not>
           <equals arg1="${domain_exists}" arg2=""/>
         </not>
         <then>
-          
+
           <wdp operation="RestartDomain" successprop="restart_success" responseprop="restart_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="restart_okay">
             <hostname>@{host}</hostname>
@@ -2785,7 +2817,7 @@
             <pwd>@{pwd}</pwd>
             <domain>@{domain}</domain>
           </wdp>
-          
+
           <if>
             <and>
               <istrue value="${restart_success}"/>
@@ -2799,18 +2831,18 @@
               <fail message="Failed to restart domain @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <echo>Did not restart domain @{domain} on @{host} since it does not exist.</echo>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Restore one or more domains from a backup created by BackupDevice or BackupDevice.
   -->
@@ -2827,10 +2859,10 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="success-update"/>
-      
+
       <!-- Restore the specified domain(s). -->
       <wdp operation="Restore" successprop="success-update" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <local>@{zipfile}</local>
@@ -2841,7 +2873,7 @@
         <uid>@{uid}</uid>
         <pwd>@{pwd}</pwd>
       </wdp>
-      
+
       <if>
         <isset property="success-update"/>
         <then>
@@ -2859,12 +2891,12 @@
           <fail message="Failed to restore from @{zipfile} on @{host}"/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Rewrite a DataPower export (.zip or .xml/.xcfg) to change object names or
     replace the existing WSDLs in a WSP with a new set of WSDLs.
@@ -2876,13 +2908,13 @@
     <attribute name="workdir"/> <!-- tmpdir where a directory can be created, if necessary -->
     <attribute name="changes" default=""/> <!-- Alternative to passing in XML content -->
     <element name="definition" implicit="yes" optional="yes"/>
-    
+
     <sequential> <!-- permit declaring some variables local in scope. -->
       <local name="inputfile.abs"/>
       <local name="object-names-present"/>
       <local name="outputfile.abs"/>
       <local name="wsdls-present"/>
-      
+
       <!-- Ensure that the input and output files are not the same file. -->
       <property name="inputfile.abs" location="@{inputfile}"/>
       <property name="outputfile.abs" location="@{outputfile}"/>
@@ -2891,7 +2923,7 @@
           <equals arg1="${inputfile.abs}" arg2="${outputfile.abs}" casesensitive="false"/>
         </condition>
       </fail>
-      
+
       <if>
         <equals arg1="@{changes}" arg2=""/>
         <then>
@@ -2901,7 +2933,7 @@
           <storexml outfile="@{workdir}/dcmpolicy.xml">@{changes}</storexml>
         </else>
       </if>
-      
+
       <!--
         Prepare the .zip/.xcfg file - rewriting if necessary.  The name of the (rewritten) file ends up in
         ${export_file}.
@@ -2917,7 +2949,7 @@
         </or>
         <then>
           <!--
-            Rewrite the export to account for renaming objects and/or new WSDLs. 
+            Rewrite the export to account for renaming objects and/or new WSDLs.
           -->
           <if>
             <matches string="@{inputfile}" pattern="\.zip$" casesensitive="false"/>
@@ -2946,12 +2978,12 @@
           <copy file="@{inputfile}" tofile="@{outputfile}" overwrite="true"/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Rollback a domain to a checkpoint
   -->
@@ -2966,12 +2998,12 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma"/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="rollbackcheckpoint_okay"/>
       <local name="rollbackcheckpoint_response"/>
       <local name="rollbackcheckpoint_success"/>
-      
+
       <wdp operation="RollbackCheckpoint" successprop="rollbackcheckpoint_success" responseprop="rollbackcheckpoint_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}"
         xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="rollbackcheckpoint_okay" capturesoma="@{capturesoma}">
         <hostname>@{host}</hostname>
@@ -2981,7 +3013,7 @@
         <domain>@{domain}</domain>
         <name>@{checkpoint-name}</name>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${rollbackcheckpoint_success}"/>
@@ -2997,8 +3029,8 @@
       </if>
     </sequential>
   </macrodef>
-  
-  
+
+
   <!--
     Create (save) a checkpoint
   -->
@@ -3018,7 +3050,7 @@
       <local name="savecheckpoint_okay"/>
       <local name="savecheckpoint_response"/>
       <local name="savecheckpoint_success"/>
-      
+
       <wdp operation="SaveCheckpoint" successprop="savecheckpoint_success" responseprop="savecheckpoint_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}"
         xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="savecheckpoint_okay" capturesoma="@{capturesoma}">
         <hostname>@{host}</hostname>
@@ -3028,7 +3060,7 @@
         <domain>@{domain}</domain>
         <name>@{checkpoint-name}</name>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${savecheckpoint_success}"/>
@@ -3044,22 +3076,22 @@
       </if>
     </sequential>
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Save the domain is changed.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - name of domain on device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="saveDomainIfChanged">
     <attribute name="host"/>
@@ -3072,19 +3104,19 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="save_needed"/>
-      
+
       <fail message="The domainStatusProp attribute was not supplied in the ant script invoking &lt;saveDomainIfChanged&gt;!">
         <condition>
           <equals arg1="@{domainStatusProp}" arg2=""/>
         </condition>
       </fail>
-      
-      <xpath inprop="@{domainStatusProp}" outprop="save_needed" 
+
+      <xpath inprop="@{domainStatusProp}" outprop="save_needed"
       xpath="/status/DomainStatus[Domain='@{domain}']/SaveNeeded"/>
-      
+
       <if>
         <equals arg1="${save_needed}" arg2="on"/>
         <then>
@@ -3092,26 +3124,26 @@
             dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}" ignore-errors="@{ignore-errors}"/>
         </then>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Save the domain is changed and the user responds affirmatively to a prompt at the console.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - name of domain on device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="saveDomainIfChangedPrompt">
     <attribute name="host"/>
@@ -3124,24 +3156,24 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="answer"/>
       <local name="save_needed"/>
-      
+
       <fail message="The domainStatusProp attribute was not supplied in the ant script invoking &lt;saveDomainIfChangedPrompt&gt;!">
         <condition>
           <equals arg1="@{domainStatusProp}" arg2=""/>
         </condition>
       </fail>
-      
-      <xpath inprop="@{domainStatusProp}" outprop="save_needed" 
+
+      <xpath inprop="@{domainStatusProp}" outprop="save_needed"
         xpath="/status/DomainStatus[Domain='@{domain}']/SaveNeeded"/>
-      
+
       <if>
         <equals arg1="${save_needed}" arg2="on"/>
         <then>
-          
+
           <input validargs="y,s,h" addproperty="answer">Save domain @{domain} now (yes, skip saving, halt ANT script)?</input>
           <if>
             <equals arg1="${answer}" arg2="y"/>
@@ -3149,7 +3181,7 @@
 
               <saveDomainUnconditionally host="@{host}" port="@{port}" uid="@{uid}" pwd="@{pwd}" domain="@{domain}"
                 dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}" ignore-errors="@{ignore-errors}"/>
-              
+
             </then>
           </if>
           <if>
@@ -3158,29 +3190,29 @@
               <fail message="Stopping early because you chose 'halt' when asked about saving a domain."/>
             </then>
           </if>
-          
+
         </then>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Save the domain unconditionally.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - name of domain on device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="saveDomainUnconditionally">
     <attribute name="host"/>
@@ -3192,11 +3224,11 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="save_okay"/>
       <local name="save_response"/>
-<!--      
+<!--
       <echo>saveDomainUnconditionally : host=@{host}</echo>
       <echo>saveDomainUnconditionally : port=@{port}</echo>
       <echo>saveDomainUnconditionally : uid=@{uid}</echo>
@@ -3207,8 +3239,8 @@
       <echo>saveDomainUnconditionally : ignore-errors=@{ignore-errors}</echo>
 -->
       <!-- Save this domain -->
-      <wdp operation="SaveConfig" responseprop="save_response" 
-        xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="save_okay" 
+      <wdp operation="SaveConfig" responseprop="save_response"
+        xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="save_okay"
         dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <domain>@{domain}</domain>
         <host>@{host}</host>
@@ -3217,7 +3249,7 @@
         <pwd>@{pwd}</pwd>
         <ignore-errors>@{ignore-errors}</ignore-errors>
       </wdp>
-      
+
       <if>
         <equals arg1="${save_okay}" arg2="OK"/>
         <then>
@@ -3228,12 +3260,12 @@
           <fail message="Failed to save domain @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Perform a secure backup of the appliance.
   -->
@@ -3249,9 +3281,9 @@
     <attribute name="dumpoutput" default="false" />
     <attribute name="capturesoma"/>
     <attribute name="ignore-errors" default="false" />
-    
+
     <sequential>
-      
+
       <local name="capture"/>
       <local name="success" />
       <wdp operation="SecureBackup" successprop="success" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
@@ -3262,9 +3294,9 @@
         <objname>@{objname}</objname>
         <remote>@{remote}</remote>
       </wdp>
-      
+
       <if>
-        
+
         <istrue value="${success}" />
         <then>
           <echo message="Secure backup successful to @{remote}" />
@@ -3272,27 +3304,27 @@
         <else>
           <fail message="Secure Backup failed." />
         </else>
-        
+
       </if>
     </sequential>
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Set the log level in a domain (for the default log).
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - domain on the device
       loglevel - debug, info, noice, warn, error, critic, alert, emerg
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="setLogLevel">
     <attribute name="host"/>
@@ -3305,24 +3337,24 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="set_okay"/>
       <local name="set_success"/>
       <local name="domain_exists"/>
       <local name="domainlist"/>
-      
+
       <getDomainStatus host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" domainsprop="domainlist" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
-      <xpath inprop="domainlist" outprop="domain_exists" 
+
+      <xpath inprop="domainlist" outprop="domain_exists"
         xpath="/status/DomainStatus[Domain='@{domain}']"/>
-      
+
       <if>
         <not>
           <equals arg1="${domain_exists}" arg2=""/>
         </not>
         <then>
-          
+
           <wdp operation="SetLogLevel" successprop="set_success" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="set_okay">
             <hostname>@{host}</hostname>
@@ -3332,7 +3364,7 @@
             <domain>@{domain}</domain>
             <loglevel>@{loglevel}</loglevel>
           </wdp>
-          
+
           <if>
             <and>
               <istrue value="${set_success}"/>
@@ -3346,18 +3378,18 @@
               <fail message="Failed to set log level in domain @{domain} on @{host} to @{loglevel."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <echo>Did set log level in domain @{domain} on @{host} since that domain does not exist.</echo>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Create a valcred based on a few parameters and an implicit FileSet.
   -->
@@ -3374,29 +3406,29 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <element name="definition" implicit="yes"/>
-    
+
     <sequential>
       <local name="response-create"/>
       <local name="success-create"/>
       <local name="uploadedfiles"/>
       <local name="valcred-objname"/>
-      
+
       <!-- Upload all the files in the specified directory.  These are all supposed to be certificate files for this valcred object. -->
-      <dpupload dir="@{rootdir}" target="cert:///" domain="@{domain}" url="https://@{host}:@{port}/service/mgmt/current" uid="@{uid}" pwd="@{pwd}" 
+      <dpupload dir="@{rootdir}" target="cert:///" domain="@{domain}" url="https://@{host}:@{port}/service/mgmt/current" uid="@{uid}" pwd="@{pwd}"
         uploadedfilesprop="uploaded-files" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <definition/>
       </dpupload>
-      
+
       <!-- <echo>uploaded-files = ${uploaded-files}</echo> -->
-      
+
       <!-- Generate the guts of a SetConfig, comprised of Crypto Certificate objects and a Validation Credential object. -->
       <property name="valcred-objname" value="@{objname}"/>
       <nxslt inprop="uploaded-files" outprop="config" xsl="@{dcmdir}/src/generate-valcred.xsl">
         <param ant="valcred-objname" xsl="objname"/>
       </nxslt>
-      
+
       <!-- <echo>config = ${config}</echo> -->
-      
+
       <wdp operation="SetConfig" successprop="success-create" responseprop="response-create" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
         <wrapper>${config}</wrapper>
         <hostname>@{host}</hostname>
@@ -3404,10 +3436,10 @@
         <pwd>@{pwd}</pwd>
         <domain>@{domain}</domain>
       </wdp>
-      
+
       <!-- <echo>response-create = ${response-create}</echo> -->
       <!-- <echo>success-create = ${success-create}</echo> -->
-      
+
       <if>
         <and>
           <isset property="success-create"/>
@@ -3420,12 +3452,12 @@
           <fail message="Failed to create the Validation Credential object @{objname} or one or more certificate objects"/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
     Unimport some DataPower export.
   -->
@@ -3443,7 +3475,7 @@
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
     <element name="definition" implicit="yes"/>
-    
+
     <sequential>
       <local name="exportname"/>
       <local name="exportxml"/>
@@ -3452,13 +3484,13 @@
       <local name="delete_success"/>
       <local name="objects_delete"/>
       <local name="objects_disable"/>
-      
+
       <!-- Rewrite the DP export to account for changes to object names or WSDLs (in a WSP), or just copy the DP export file. -->
       <basename property="exportname" file="@{inputfile}"/>
       <rewriteExport inputfile="@{inputfile}" outputfile="@{workdir}/${exportname}" dcmdir="@{dcmdir}" workdir="@{workdir}">
         <definition/> <!-- placeholder for dcm:definition provided as content of <unimportConfig> -->
       </rewriteExport>
-      
+
       <!-- Access the rewritten export.xml - Note that this code depends on the internals of <rewriteExport>! -->
       <if>
         <matches string="${exportname}" pattern="\.zip$" casesensitive="false"/>
@@ -3469,10 +3501,10 @@
           <property name="exportxml" location="@{workdir}/${exportname}"/>
         </else>
       </if>
-      
+
       <!-- Capture the list of objects to delete, in proper order. -->
       <nxslt infile="${exportxml}" outprop="objects_disable" xsl="@{dcmdir}/src/unimport-extract-disable.xsl"/>
-      
+
       <!-- Capture the list of objects to delete, in proper order. -->
       <nxslt infile="${exportxml}" outprop="objects_delete" xsl="@{dcmdir}/src/unimport-extract-delete.xsl"/>
 
@@ -3486,12 +3518,12 @@
         <pwd>@{pwd}</pwd>
         <ignore-errors>true</ignore-errors>
       </wdp>
-      
-      <!-- 
+
+      <!--
         Delete the objects multiple times.  This is due to a race condition where some objects are reported as "deleted"
         but they are in fact still being shut down.  This simple heuristic has been sufficient so far, but it is a heuristic,
         not a perfect solution.
-        
+
         The race condition first appeared while deleting an MPGW with an MQ FSH and MQ QM.  We deleted the MQ FSH just fine, but
         the next object we deleted, the MQ QM, fails to delete because it was still in use by the MQ FSH, which apparently had not
         finished being destroyed.  Since it was a race condition, sometimes the MQ QM deleted successfully and sometimes not.
@@ -3524,7 +3556,7 @@
         <pwd>@{pwd}</pwd>
         <ignore-errors>@{ignore-errors}</ignore-errors>
       </wdp>
-      
+
       <if>
         <and>
           <istrue value="${delete_success}"/>
@@ -3538,26 +3570,26 @@
           <fail message="Failed to unimport @{inputfile} from domain @{domain} on @{host}."/>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!--
-    
+
     Unquiesce all the services in a domain, when it exists.
-    
+
     Required parameters:
       host - hostname or IP address of DataPower device
       domain - domain on the device
       uid - userid
       pwd - password
-    
+
     Optional parameters:
       port - XML Management Interface port on device (defaults to 5550)
       ignore-errors = true() or false()
-    
+
   -->
   <macrodef name="unquiesceDomain">
     <attribute name="host"/>
@@ -3569,24 +3601,24 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="unquiesce_okay"/>
       <local name="unquiesce_response"/>
       <local name="unquiesce_success"/>
       <local name="domain_exists"/>
       <local name="domainlist"/>
-      
+
       <getDomainStatus host="@{host}" uid="@{uid}" pwd="@{pwd}" port="@{port}" domainsprop="domainlist" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"/>
-      
+
       <xpath inprop="domainlist" outprop="domain_exists" xpath="/status/DomainStatus[Domain='@{domain}']"/>
-      
+
       <if>
         <not>
           <equals arg1="${domain_exists}" arg2=""/>
         </not>
         <then>
-          
+
           <wdp operation="UnquiesceDomain" successprop="unquiesce_success" responseprop="unquiesce_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
             xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="unquiesce_okay">
             <hostname>@{host}</hostname>
@@ -3596,7 +3628,7 @@
             <domain>@{domain}</domain>
             <timeout>@{timeout}</timeout>
           </wdp>
-          
+
           <if>
             <and>
               <istrue value="${unquiesce_success}"/>
@@ -3610,19 +3642,19 @@
               <fail message="Failed to unquiesce domain @{domain} on @{host}."/>
             </else>
           </if>
-          
+
         </then>
         <else>
           <echo>Did not unquiesce domain @{domain} on @{host} since it does not exist.</echo>
         </else>
       </if>
-      
+
     </sequential>
-    
+
   </macrodef>
-  
-  
-  <!-- 
+
+
+  <!--
     Unquiesce a service
   -->
   <macrodef name="unquiesceService">
@@ -3638,7 +3670,7 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma"/>
     <attribute name="ignore-errors" default="false"/>
-    
+
     <sequential>
       <local name="unquiesce_okay"/>
       <local name="unquiesce_response"/>
@@ -3678,7 +3710,7 @@
     <attribute name="param1" default=""/>
     <attribute name="param2" default=""/>
     <attribute name="param3" default=""/>
-    
+
     <sequential>
       <xslt in="@{in}" out="@{out}" style="@{xsl}">
         <factory name="org.apache.xalan.processor.TransformerFactoryImpl">
@@ -3692,10 +3724,10 @@
         <param name="param3" expression="@{param3}"/>
       </xslt>
     </sequential>
-    
+
   </macrodef>
-  
-  
+
+
   <!-- Convenient definition to supply a default value when the specified value is empty. -->
   <macrodef name="defprop">
     <attribute name="name"/>
@@ -3716,8 +3748,8 @@
       </if>
     </sequential>
   </macrodef>
-  
-  
+
+
   <!-- Convenient definition to supply a default value when the specified property is empty or not set. -->
   <macrodef name="defprop-set">
     <attribute name="name"/>

--- a/src/main/zip/RunDeployDotAnt.groovy
+++ b/src/main/zip/RunDeployDotAnt.groovy
@@ -82,6 +82,12 @@ try
                  '-Dpwd=' + props['pwd'],
                  '-Dwork.dir=' + ch.getProcessBuilder().directory().getAbsolutePath() + '/tmp']
 
+  // Add -Dignore.error if specified
+  def ignoreError = props['ignoreError']
+  if (ignoreError) {
+      antargs << "-Dignore.error=" + ignoreError
+  }
+
   // When addlProperties != '' then we pick out one or more mappings from UCD properties
   // to additional ant properties.  For example, crypto.dir=${p:resource/work.dir}${p:component.name}/ucdDemo/crypto
   // will pass -Dcrypto.dir=... to deploy.ant.xml. Multiple properties may be defined, separated by '~' characters.

--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -148,6 +148,10 @@
         New functionality added to all steps:
             - The hidden Java Max Memory Size variable has new -Xmx4096m, ${p?:environment/memorySize}, and ${p?:resource/memorySize} options.
     </release-note>
+    <release-note plugin-version="13">
+        New functionality added to the Import (Basic), Import (Definition), and Import (Deployment Policy Object) steps:
+            - The hidden Import Error Regex variable can be utilized to ignore SOMA error responses.
+    </release-note>
 
   </release-notes>
 </pluginInfo>

--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -146,7 +146,7 @@
     </release-note>
     <release-note plugin-version="12">
         New functionality added to all steps:
-            - The hidden Java Max Memory Size variable has new -Xmx4096m, ${p?:environment/memorySize, and ${p?:resource/memorySize} options.
+            - The hidden Java Max Memory Size variable has new -Xmx4096m, ${p?:environment/memorySize}, and ${p?:resource/memorySize} options.
     </release-note>
 
   </release-notes>

--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -149,7 +149,7 @@
             - The hidden Java Max Memory Size variable has new -Xmx4096m, ${p?:environment/memorySize}, and ${p?:resource/memorySize} options.
     </release-note>
     <release-note plugin-version="13">
-        New functionality added to the Import (Basic), Import (Definition), and Import (Deployment Policy Object) steps:
+        Fixes APAR PI79894 - New functionality added to the Import (Basic), Import (Definition), and Import (Deployment Policy Object) steps:
             - The hidden Import Error Regex variable can be utilized to ignore SOMA error responses.
     </release-note>
 

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -19,7 +19,7 @@
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <header>
-    <identifier version="12" id="com.ibm.datapower" name="DataPower"/>
+    <identifier version="13" id="com.ibm.datapower" name="DataPower"/>
     <description>The IBM WebSphere DataPower plugin deploys DataPower services.</description>
     <tag>Infrastructure/WebSphere DataPower</tag>
   </header>
@@ -884,6 +884,9 @@
           <value label="${p?:environment/memorySize}">${p?:environment/memorySize}</value>
           <value label="${p?:resource/memorySize}">${p?:resource/memorySize}</value>
       </property>
+      <property name="ignoreError">
+        <property-ui type="textBox" default-value="" label="Import Error Regex" description="Specify regex that defines import error(s) to ignore on completion." hidden="true"/>
+      </property>
     </properties>
     <post-processing><![CDATA[
     if (properties.get("exitCode") != 0) {
@@ -948,6 +951,9 @@
           <value label="-Xmx4096m">-Xmx4096m</value>
           <value label="${p?:environment/memorySize}">${p?:environment/memorySize}</value>
           <value label="${p?:resource/memorySize}">${p?:resource/memorySize}</value>
+      </property>
+      <property name="ignoreError">
+        <property-ui type="textBox" default-value="" label="Import Error Regex" description="Specify regex that defines import error(s) to ignore on completion." hidden="true"/>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -1014,6 +1020,9 @@
           <value label="-Xmx4096m">-Xmx4096m</value>
           <value label="${p?:environment/memorySize}">${p?:environment/memorySize}</value>
           <value label="${p?:resource/memorySize}">${p?:resource/memorySize}</value>
+      </property>
+      <property name="ignoreError">
+        <property-ui type="textBox" default-value="" label="Import Error Regex" description="Specify regex that defines import error(s) to ignore on completion." hidden="true"/>
       </property>
     </properties>
     <post-processing><![CDATA[

--- a/src/main/zip/upgrade.xml
+++ b/src/main/zip/upgrade.xml
@@ -516,4 +516,22 @@
       </migrate-properties>
     </migrate-command>
   </migrate>
+
+  <migrate to-version="13">
+    <migrate-command  name="Import (Basic)">
+      <migrate-properties>
+        <migrate-property name="ignoreError" default=""/>
+      </migrate-properties>
+    </migrate-command>
+    <migrate-command  name="Import (Definition)">
+      <migrate-properties>
+        <migrate-property name="ignoreError" default=""/>
+      </migrate-properties>
+    </migrate-command>
+      <migrate-command  name="Import (Deployment Policy Object)">
+        <migrate-properties>
+          <migrate-property name="ignoreError" default=""/>
+        </migrate-properties>
+      </migrate-command>
+  </migrate>
 </plugin-upgrade>


### PR DESCRIPTION
Fixes issue #43 where the user can now specify an import error regex to ignore following the completion of the import. 

For example....

After import, if a "No access to file" import error is found, you can specify the hidden "Import Error Regex" property field to properly ignore against this specific error. This provides an easy work around within the plugin that helps match functionality that SOMA and cli calls possess outside of the plugin. 