### PR TITLE
Added the ability to export all files for the export-object target

### DIFF
--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -655,7 +655,7 @@
 
     <exportObject host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" local="${export.file}"
       dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"
-      objclass="${object.class}" objname="${object.name}" refobjs="${ref.objects}" reffiles="${ref.files}" />
+      objclass="${object.class}" objname="${object.name}" refobjs="${ref.objects}" reffiles="${ref.files}" allfiles="${all.files}" />
 
   </target>
 

--- a/src/dcm-taskdefs.ant.xml
+++ b/src/dcm-taskdefs.ant.xml
@@ -106,6 +106,7 @@
     <attribute name="objname" />
     <attribute name="refobjs"  default="true"/>
     <attribute name="reffiles" default="true"/>
+    <attribute name="allfiles" default="false"/>
 
     <sequential>
       <local name="export_success"/>
@@ -123,6 +124,7 @@
           <pwd>@{pwd}</pwd>
           <ignore-errors>@{ignore-errors}</ignore-errors>
           <domain>@{domain}</domain>
+          <all-files>@{allfiles}</all-files>
       </wdp>
 
       <if>


### PR DESCRIPTION
Files, like WSDLs, that point to other files aren't included in the export.
We made a build process that: 
1) Creates a new domain 
2) Imports configuration and upload files
3) Exports all the files and the configuration into one zip
4) Deletes the domain

Since the Soma.java already supports it the changes are minimal :+1: 