### PR TITLE
Default value for all.files property

### DIFF
--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -655,7 +655,7 @@
 
     <exportObject host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" local="${export.file}"
       dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"
-      objclass="${object.class}" objname="${object.name}" refobjs="${ref.objects}" reffiles="${ref.files}" />
+      objclass="${object.class}" objname="${object.name}" refobjs="${ref.objects}" reffiles="${ref.files}" allfiles="${all.files}" />
 
   </target>
 

--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -637,6 +637,7 @@
 
     <property name="ref.objects" value="true"/> <!-- provide defaults if not specified by user -->
     <property name="ref.files" value="true"/>
+    <property name="all.files" value="false"/>
 
     <sequential>
       <local name="dirname"/>

--- a/src/dcm-taskdefs.ant.xml
+++ b/src/dcm-taskdefs.ant.xml
@@ -106,6 +106,7 @@
     <attribute name="objname" />
     <attribute name="refobjs"  default="true"/>
     <attribute name="reffiles" default="true"/>
+    <attribute name="allfiles" default="false"/>
 
     <sequential>
       <local name="export_success"/>
@@ -123,6 +124,7 @@
           <pwd>@{pwd}</pwd>
           <ignore-errors>@{ignore-errors}</ignore-errors>
           <domain>@{domain}</domain>
+          <all-files>@{allfiles}</all-files>
       </wdp>
 
       <if>


### PR DESCRIPTION
I didn't add a default value for this property in my last commit.
When someone tries to use the export-object task without specifying this property it fails.