### PR TITLE
Key create target

### DIFF
--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -63,6 +63,7 @@
   import-dpo*      - import a specified .zip or .xcfg file into the domain, making changes along the way
 
   key-from-def - upload a key (or multiple keys) based on a dcm:definition (with Crypto Key objects, of course)
+  key-create - generate a private key, a public key and a self-signed certificate
 
   load-balancer-group-from-def* - create/overwrite a load balancer group object
 
@@ -1065,6 +1066,23 @@
   </target>
 
 
+  <!--
+      Generate a private key, an optional Self-Signed certificate and a CSR.
+  -->
+  <target name="key-create" depends="-init-dir, check-access">
+    <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
+    <fail message="The Ant property 'cn' is required but not defined.  This is the Common Name property of the key." unless="cn"/>
+    <property name="exportkey" value='off'/>
+    <property name="gensscert" value='off'/>
+    <property name="expsscert" value='off'/>
+
+    <keyGen host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" cn="${cn}" domain="${domain}" exportkey="${exportkey}" gensscert="${gensscert}" expsscert="${expsscert}" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
+    <echo>Generated key successfully</echo>
+
+  </target>
+
+
+
   <target name="load-balancer-group-from-def" depends="-init-dir, check-access">
 
     <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
@@ -1507,7 +1525,7 @@
 	<property name="object.class" value="PasswordAlias"/>
 	<property name="ref.objects" value="false"/>
 	<!-- provide defaults if not specified by user -->
-	<property name="ref.files" value="fasle"/>
+	<property name="ref.files" value="false"/>
 	<wdp operation="AddPasswordMap" dumpinput="true" dumpoutput="true" capturesoma="${capturesoma}">
 		<objects xmlns:soma="http://www.datapower.com/schemas/management">
 			<soma:object class="@{object.class}" name="@{password-alias.name}" ref-objects="@{refobjs}" ref-files="@{reffiles}"/>
@@ -1527,7 +1545,7 @@
 	<property name="object.class" value="PasswordAlias"/>
 	<property name="ref.objects" value="false"/>
 	<!-- provide defaults if not specified by user -->
-	<property name="ref.files" value="fasle"/>
+	<property name="ref.files" value="false"/>
 	<wdp operation="ChangePasswordMap" dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}">
 		<objects xmlns:soma="http://www.datapower.com/schemas/management">
 			<soma:object class="@{object.class}" name="@{password-alias.name}" ref-objects="@{refobjs}" ref-files="@{reffiles}"/>

--- a/src/dcm-taskdefs.ant.xml
+++ b/src/dcm-taskdefs.ant.xml
@@ -1834,6 +1834,77 @@
 
   <!--
 
+    Generate a private key, an optional SScert and a CSR.
+
+    Required parameters:
+      host - hostname or IP address of DataPower device
+      uid - userid
+      pwd - password
+      domain - name of domain for which the key(s)&csr are created
+      cn - Common Name property for the key(-pair)&csr
+
+    Optional parameters:
+      port - XML Management Interface port on device (defaults to 5550)
+      ignore-errors = true() or false()
+      exportkey = on / off(=default), whether to export the private key or not
+      gensscert = on / off(=default), whether to generate a SS-certificate or not
+      expsscert = on / off(=default), whether to export the SS-certificate or not
+
+  -->
+  <macrodef name="keyGen">
+    <attribute name="host"/>
+    <attribute name="port" default="5550"/>
+    <attribute name="uid" default="admin"/>
+    <attribute name="pwd" default="admin"/>
+    <attribute name="domain"/>
+    <attribute name="cn"/>
+    <attribute name="exportkey"/>
+    <attribute name="gensscert"/>
+    <attribute name="expsscert"/>
+    <attribute name="dumpinput" default="false"/>
+    <attribute name="dumpoutput" default="false"/>
+    <attribute name="capturesoma" default=""/>
+    <attribute name="ignore-errors" default="false"/>
+
+    <sequential>
+      <local name="generate_okay"/>
+      <local name="generate_response"/>
+      <local name="generate_success"/>
+
+      <wdp operation="Keygen" successprop="generate_success" responseprop="generate_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}"
+           xpath="normalize-space(/env:Envelope/env:Body/soma:response/soma:result)" xpathprop="generate_okay">
+        <hostname>@{host}</hostname>
+        <domain>@{domain}</domain>
+        <port>@{port}</port>
+        <uid>@{uid}</uid>
+        <pwd>@{pwd}</pwd>
+        <cn>@{cn}</cn>
+        <exportkey>@{exportkey}</exportkey>
+        <gensscert>@{gensscert}</gensscert>
+        <exportsscert>@{expsscert}</exportsscert>
+      </wdp>
+
+      <if>
+        <and>
+          <istrue value="${generate_success}"/>
+          <equals arg1="${generate_okay}" arg2="OK"/>
+        </and>
+        <then>
+          <echo>key @{cn} generated on @{domain}@@@{host}.</echo>
+        </then>
+        <else>
+          <echo>Raw response for macrodef doKeygen: ${generate_response}; dumpoutput="${dumpoutput}"</echo>
+          <fail message="Failed to generate @{cn} key at @{domain}@@@{host}."/>
+        </else>
+      </if>
+
+    </sequential>
+
+  </macrodef>
+
+
+  <!--
+
     Listing of a filestore
 
     Required parameters:


### PR DESCRIPTION
Added target key-create (deploy.ant.xml) and macrodef keyGen (src/dcm-taskdefs.ant.xml);
also spell-corrected 'fasle' --> 'false' (password-alias-create lines at deploy.ant.xml)