### PR TITLE
Parameterized reset-domain for ant CLI and UCD Plugin.

### DIFF
--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -1286,7 +1286,7 @@
 
     <restoreBackup host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}"
       domains="${domains}" zipfile="${backup.file}" dry-run="${dry-run}"
-      dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}"/>
+      dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}" reset-domain="${reset-domain}"/>
 
   </target>
 

--- a/src/com/ibm/dcm/Soma.java
+++ b/src/com/ibm/dcm/Soma.java
@@ -4239,7 +4239,7 @@ public class Soma {
 
     body.append("<soma:input-file>" + Base64.base64FromBinaryFile(params.get("local")) + "</soma:input-file>");
 
-    body.append("<soma:domain name=\"" + params.get("domain") + "\" import-domain=\"true\" reset-domain=\"true\"/>");
+    body.append("<soma:domain name=\"" + params.get("domain") + "\" import-domain=\"true\" reset-domain=\"" + params.get("reset-domain") + "\"/>");
     if (params.get("domains") != null) {
 
       // Parse the list of domain names, which are merely whitespace separated.
@@ -4249,7 +4249,7 @@ public class Soma {
       for (int i = 0; i < names.length; i += 1) {
         if (names[i].equals(params.get("domain")) == false) {
           // Not the primary domain so add this to the list.
-          body.append("<soma:domain name=\"" + names[i] + "\"/>");
+          body.append("<soma:domain name=\"" + names[i] + "\" import-domain=\"true\" reset-domain=\"" + params.get("reset-domain") + "\"/>");
         }
       }
     }

--- a/src/dcm-taskdefs.ant.xml
+++ b/src/dcm-taskdefs.ant.xml
@@ -2938,6 +2938,7 @@
     <attribute name="dumpoutput" default="false"/>
     <attribute name="capturesoma" default=""/>
     <attribute name="ignore-errors" default="false"/>
+    <attribute name="reset-domain" default="true"/>
 
     <sequential>
       <local name="success-update"/>
@@ -2951,6 +2952,7 @@
         <hostname>@{host}</hostname>
         <uid>@{uid}</uid>
         <pwd>@{pwd}</pwd>
+        <reset-domain>@{reset-domain}</reset-domain>
       </wdp>
 
       <if>

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -1437,6 +1437,11 @@
       <property name="environment">
         <property-ui type="textBox" default-value="${p:environment.name}" label="Target Environment" description="Target environment (e.g. dev, sit, uat, prod)" hidden="true"/>
       </property>
+      <property name="resetDomains">
+        <property-ui type="selectBox" default-value="true" label="Reset Domains" description="Reset domain being restored." hidden="true"/>
+          <value label="True">true</value>
+          <value label="False">false</value>
+      </property>
       <property name="addlProperties">
         <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
       </property>
@@ -1470,6 +1475,7 @@
       <arg value="-Ddomains=@domainNames@"/>
       <arg value="-Denvironment=@environment@"/>
       <arg value="-Dbackup.file=@backupFile@"/>
+      <arg value="-Dreset-domain=@resetDomains@"/>
       <arg value="restore-backup"/>
     </command>
   </step-type>


### PR DESCRIPTION
doRestore method in src/com/ibm/dcm/Soma.java hard coded reset-domain=true
in the generation of the SOMA command that is sent to DataPower.  This change
allows that value to be passed to the dcm ant command line tool and via
the UCD plugin.  In addition, the additional domains feature did not reset
the domains like the first domain was being reset, therefore I added the
reset-domain paramter to that line of code as well.  The hard coded value
of reset-domain was true, so the default value for this is also true as to
not break existing users.

This change is to allow the user to decide wether or not to reset-domain
during a doRestore.  Problems present themselves with exporting and importing
backups between equivalent devices (DataPowers behind a Load Balancer).
Domain backups do not export passwords, this is problematic when importing
the config to an equivalent domain on another DataPower as the reset-domain
causes the objects to be removed and reimported, causing the password in
the password map alias to be lost.  As a result, the object that references
the password map alias will transition to a down state, potentially causing
a service outage.