### PR TITLE
set SSLClientConfigType to "proxy" if ssl-proxy-profile is used

### DIFF
--- a/src/load-balancer-group-to-ant.xsl
+++ b/src/load-balancer-group-to-ant.xsl
@@ -554,7 +554,17 @@
               <xsl:value-of select="'Full'"/>
             </xsl:element>
             <xsl:element name="SSLClientConfigType">
-              <xsl:value-of select="'client'"/>
+              <xsl:choose>
+                <xsl:when test="$checks/@ssl-client != ''">
+                   <xsl:value-of select="'client'"/>
+                </xsl:when>
+                <xsl:when test="$checks/@ssl-proxy-profile != ''">
+                   <xsl:value-of select="'proxy'"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="'client'"/>
+                </xsl:otherwise>
+              </xsl:choose>
             </xsl:element>
     	    <xsl:element name="SSLClient">
               <xsl:if test="$checks/@ssl-client != ''">


### PR DESCRIPTION
The current load-balancer-group-to-ant.xsl version does not cater for the "proxy" setting of  "SSLClientConfigType" on LBG health checks - specifically when set using the "ssl-proxy-profile" argument of "dcm:loadbalancergroup".

Not setting the correct value for "SSLClientConfigType" when a SSLProxyProfile object is used results in the profile name being unset leaving the SSL profile unconfigured.

Here's the "LBGroupChecks" section from the export.xml for a LBG that uses a SSLProxyProfile on the health check - notice "SSLClientConfigType" at the end and "SSLProxyProfile" in the middle:
`<LBGroupChecks>
    <Active>on</Active>
    <URI>/public/ping</URI>
    <Port>80</Port>
    <SSL>Standard</SSL>
    <Post>off</Post>
    <Input>store:///healthcheck.xml</Input>
    <Timeout>10</Timeout>
    <Frequency>5</Frequency>
    <XPath>/</XPath>
    <Filter>store:///healthcheck.xsl</Filter>
    <SSLProxyProfile class="SSLProxyProfile">Datapower</SSLProxyProfile>
    <EnforceTimeout>off</EnforceTimeout>
    <IndependentChecks>off</IndependentChecks>
    <GatewayScriptChecks>off</GatewayScriptChecks>
    <GatewayScriptReqMethod>GET</GatewayScriptReqMethod>
    <GatewayScriptCustomReqMethod/>
    <GatewayScriptReqDoc/>
    <GatewayScriptReqContentType>application/json</GatewayScriptReqContentType>
    <GatewayScriptRspHandlerMetadata/>
    <GatewayScriptRspHandler>store:///healthcheck.js</GatewayScriptRspHandler>
    <TCPConnectionType>Full</TCPConnectionType>
    <SSLClientConfigType>proxy</SSLClientConfigType>
    <SSLClient/>
</LBGroupChecks>`

Indeed SSLProxyProfile objects are being deprecated in favour of SSLClientProfile objects - but at least this change makes "dcm:loadbalancergroup" usable for both types until such time when all configuration has been migrated to use SSLClientProfile objects.   

The change only affects the mapping for the SSLClientConfigType element of LBGroupChecks.  The xsl:choose conditions ensures that the "ssl-client" is used in the event that both "ssl-client" and "ssl-proxy-profile" is set.

This was tested on firmware 2018.4.1.5.  

Here's the "dcm:health-checks" element from the definition that was used:
`<dcm:health-checks enabled="true" uri="/public/ping" port="80" ssl="Standard" post="off" input="store:///healthcheck.xml" timeout="10" frequency="5" xpath="/" filter="store:///healthcheck.xsl" ssl-proxy-profile="Datapower" enforce-timeout="off" independent-checks="off"/>`

Please advise.

H.



