### PR TITLE
Update AirPluginTool.groovy

### DIFF
--- a/src/main/zip/classes/com/urbancode/air/AirPluginTool.groovy
+++ b/src/main/zip/classes/com/urbancode/air/AirPluginTool.groovy
@@ -44,7 +44,7 @@ public class AirPluginTool {
     public Properties getStepProperties() {
         def props = new Properties();
         final def inputPropsFile = this.inPropsFile;
-        final def inputPropsStream = null;
+        def inputPropsStream = null;
         try {
             inputPropsStream = new FileInputStream(inputPropsFile);
             props.load(inputPropsStream);
@@ -63,7 +63,7 @@ public class AirPluginTool {
     }
 
     public void setOutputProperties() {
-        final OutputStream outputPropsStream = null;
+        OutputStream outputPropsStream = null;
         try {
             outputPropsStream = new FileOutputStream(this.outPropsFile);
             outProps.store(outputPropsStream, "");


### PR DESCRIPTION
Fix issues with final def after UCD v7.2 moved to groovy 3 causing the below error fixing issue 129.

https://github.com/ibm-datapower/datapower-configuration-manager/issues/129

org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
file:/opt/IBM/ibm-ucd/agent/var/plugins/com.ibm.datapower_21_c161d6fcc56f21d3ce0c76843d79fb8938d175ab1c312601b59cce03dd6d456d/classes/com/urbancode/air/AirPluginTool.groovy: 49: The variable [inputPropsStream] is declared final but is reassigned
. At [49:13]  @ line 49, column 13.
               inputPropsStream = new FileInputStream(inputPropsFile);
               ^

1 error